### PR TITLE
Fix path to license.txt

### DIFF
--- a/nuget/packaging.props
+++ b/nuget/packaging.props
@@ -3,8 +3,7 @@
 
   <PropertyGroup>
     <PackageDescriptionFile>$(MSBuildThisFileDirectory)/descriptions.json</PackageDescriptionFile>
-    <PackageLicenseFile>$(RepoRoot)/LICENSE.TXT</PackageLicenseFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseFile>$(RepoRoot)/llvm/LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(RepoRoot)/THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
 
     <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</ReleaseNotes>


### PR DESCRIPTION
This should remove the need for PackageLicenseExpression (according to the docs you can only specify one of these properties)