### PR TITLE
Fix LLVM build script to work with both netcore and Mono packaging.

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -2,31 +2,56 @@
   <Import Project="Directory.Build.props" />
   <Import Project="Directory.Build.targets" />
 
-  <Target Name="Build">
+  <PropertyGroup>
+    <_LLVMSourceDir Condition="'$(_LLVMBuildDir)'==''">$(MSBuildProjectDirectory)/llvm</_LLVMSourceDir>
+    <_LLVMBuildDir Condition="'$(_LLVMBuildDir)'==''">$(MSBuildProjectDirectory)/artifacts/tmp/BuildRoot</_LLVMBuildDir>
+    <_LLVMInstallDir Condition="'$(_LLVMInstallDir)'==''">$(MSBuildProjectDirectory)/artifacts/tmp/InstallRoot</_LLVMInstallDir>
+  </PropertyGroup>
+
+  <Target Name="_LLVMBeforeBuild">
+    <MakeDir Directories="$(_LLVMBuildDir)" Condition="!Exists('$(_LLVMBuildDir)')" />
+  </Target>
+
+  <Target Name="_LLVMAfterBuild">
+    <RemoveDir Directories="$(_LLVMInstallDir)/share" />
     <ItemGroup>
-      <_LlvmBuildArg Include="-DCMAKE_BUILD_TYPE=Release" />
-      <_LlvmBuildArg Include="-DLLVM_INCLUDE_TESTS:BOOL=OFF" />
-      <_LlvmBuildArg Include='-DCMAKE_C_FLAGS="-I../llvm/include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"' />
-      <_LlvmBuildArg Include='-DCMAKE_CXX_FLAGS="-I../llvm/include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"' />
-      <_LlvmBuildArg Include='-DLLVM_TARGETS_TO_BUILD="X86%3BAArch64%3BARM"' />
-    </ItemGroup>
-    <MakeDir Directories="$(MSBuildProjectDirectory)\artifacts\tmp\BuildRoot" Condition="!Exists('$(MSBuildProjectDirectory)\artifacts\tmp\BuildRoot')" />
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)\artifacts\tmp\BuildRoot" Command="cmake $(MSBuildProjectDirectory)/llvm/ @(_LlvmBuildArg->'%(Identity)',' ')" Condition="'$(OS)' != 'Windows_NT' AND !Exists('$(MSBuildProjectDirectory)\artifacts\tmp\BuildRoot\CMakeCache.txt')" IgnoreStandardErrorWarningFormat="true" />
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)\artifacts\tmp\BuildRoot" Command="make all -j8" IgnoreStandardErrorWarningFormat="true" Condition="'$(OS)' != 'Windows_NT'" />
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)\artifacts\tmp\BuildRoot" Command="$(MSBuildProjectDirectory)\llvm\scripts\ci\run-jenkins-windows.bat" IgnoreStandardErrorWarningFormat="true" Condition="'$(OS)' == 'Windows_NT'" />
-    <Exec WorkingDirectory="$(MSBuildProjectDirectory)\artifacts\tmp\BuildRoot" Command="cmake -DCMAKE_INSTALL_PREFIX=$(MSBuildProjectDirectory)/artifacts/tmp/InstallRoot -P cmake_install.cmake" />
-    <RemoveDir Directories="$(MSBuildProjectDirectory)\artifacts\tmp\InstallRoot\share" />
-    <ItemGroup>
-      <FilesToDelete Include="$(MSBuildProjectDirectory)\artifacts\tmp\InstallRoot\lib\libLTO*" />
-      <FilesToDelete Include="$(MSBuildProjectDirectory)\artifacts\tmp\InstallRoot\lib\BugpointPasses.*" />
+      <FilesToDelete Include="$(_LLVMInstallDir)/lib/libLTO*" />
+      <FilesToDelete Include="$(_LLVMInstallDir)/lib/BugpointPasses.*" />
     </ItemGroup>
     <Delete Files="@(FilesToDelete)" ContinueOnError="true" TreatErrorsAsWarnings="true" />
   </Target>
 
+  <Target Name="_LLVMBuildWindows" Condition="'$(OS)' == 'Windows_NT'">
+    <Exec WorkingDirectory="$(_LLVMBuildDir)"
+          Command="$(_LLVMSourceDir)/scripts/ci/run-jenkins-windows.bat &quot;$(_LLVMSourceDir)&quot; &quot;$(_LLVMBuildDir)&quot; &quot;$(_LLVMInstallDir)&quot;"
+          IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+  <Target Name="_LLVMBuildNoneWindows" Condition="'$(OS)' != 'Windows_NT'">
+    <ItemGroup>
+      <_LLLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=Release" />
+      <_LLLVMBuildArgs Include="-DLLVM_INCLUDE_TESTS:BOOL=OFF" />
+      <_LLLVMBuildArgs Include='-DCMAKE_C_FLAGS="-I../llvm/include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"' />
+      <_LLLVMBuildArgs Include='-DCMAKE_CXX_FLAGS="-I../llvm/include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"' />
+      <_LLLVMBuildArgs Include='-DLLVM_TARGETS_TO_BUILD="X86%3BAArch64%3BARM"' />
+    </ItemGroup>
+
+    <Exec WorkingDirectory="$(_LLVMBuildDir)"
+          Command="cmake $(_LLVMSourceDir) @(_LLLVMBuildArgs->'%(Identity)',' ')"
+          Condition="!Exists('$(_LLVMBuildDir)/CMakeCache.txt')"
+          IgnoreStandardErrorWarningFormat="true" />
+    <Exec WorkingDirectory="$(_LLVMBuildDir)"
+          Command="make all -j8"
+          IgnoreStandardErrorWarningFormat="true"  />
+    <Exec WorkingDirectory="$(_LLVMBuildDir)"
+          Command="cmake -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -P cmake_install.cmake" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="_LLVMBeforeBuild;_LLVMBuildWindows;_LLVMBuildNoneWindows;_LLVMAfterBuild" />
   <Target Name="Restore" />
   <Target Name="Test" />
   <Target Name="Pack" DependsOnTargets="Build">
-    <MSBuild Projects="nuget\packages.builds" Targets="Build" />
+    <MSBuild Projects="nuget/packages.builds" Targets="Build" />
   </Target>
 </Project>
 

--- a/llvm/scripts/ci/run-jenkins-windows.bat
+++ b/llvm/scripts/ci/run-jenkins-windows.bat
@@ -11,9 +11,24 @@ set BUILD_RESULT=1
 
 :: Get path for current running script.
 set RUN_JENKINS_WINDOWS_SCRIPT_PATH=%~dp0
-set MONO_LLVM_SRC_DIR=%RUN_JENKINS_WINDOWS_SCRIPT_PATH%..\..
-set MONO_LLVM_BUILD_DIR=%MONO_LLVM_SRC_DIR%\..\artifacts\tmp\BuildRoot
-set MONO_LLVM_INSTALL_DIR=%MONO_LLVM_SRC_DIR%\..\artifacts\tmp\BuildRoot
+
+set MONO_LLVM_SRC_DIR=%~1
+shift
+set MONO_LLVM_BUILD_DIR=%~1
+shift
+set MONO_LLVM_INSTALL_DIR=%~1
+
+if "%MONO_LLVM_SRC_DIR%" == "" (
+    set MONO_LLVM_SRC_DIR=%RUN_JENKINS_WINDOWS_SCRIPT_PATH%..\..
+)
+
+if "%MONO_LLVM_BUILD_DIR%" == "" (
+    set MONO_LLVM_BUILD_DIR=%MONO_LLVM_SRC_DIR%\..\builds\llvm-llvmwin64-msvc
+)
+
+if "%MONO_LLVM_INSTALL_DIR%" == "" (
+    set MONO_LLVM_INSTALL_DIR=%MONO_LLVM_SRC_DIR%\..\out\llvm-llvmwin64-msvc
+)
 
 if exist "%MONO_LLVM_BUILD_DIR%" (
     rmdir /S /Q "%MONO_LLVM_BUILD_DIR%"

--- a/llvm/scripts/ci/run-jenkins-windows.sh
+++ b/llvm/scripts/ci/run-jenkins-windows.sh
@@ -38,4 +38,4 @@ fi
 "$WINDOWS_CMD" /c "$RUN_JENKINS_WINDOWS_SCRIPT_PATH_WINDOWS"
 
 GIT_COMMIT=$(git rev-parse HEAD)
-tar cvzf llvm-llvmwin64-msvc-$GIT_COMMIT-Windows.tar.gz -C $RUN_JENKINS_WINDOWS_SCRIPT_PATH/out/llvm-llvmwin64-msvc .
+tar cvzf llvm-llvmwin64-msvc-$GIT_COMMIT-Windows.tar.gz -C $RUN_JENKINS_WINDOWS_SCRIPT_PATH/../../../out/llvm-llvmwin64-msvc .


### PR DESCRIPTION
Change src, build, install dir to input arguments. Keep original defaults and let llvm.proj pass in used directories.