### PR TITLE
Use PackageTargetRuntime not PackageRID to avoid `-amd64` arch in dir

### DIFF
--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.props
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-config" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-dis" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-tblgen" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\lib\**" Exclude="libLTO*" TargetPath="tools\$(PackageRID)\lib\%(RecursiveDir)%(Filename)%(Extension)" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\include\**" Exclude="libLTO*" TargetPath="tools\$(PackageRID)\include\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-config" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-dis" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-tblgen" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\lib\**" Exclude="libLTO*" TargetPath="tools\$(PackageTargetRuntime)\lib\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\include\**" Exclude="libLTO*" TargetPath="tools\$(PackageTargetRuntime)\include\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.props
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-config" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-dis" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-tblgen" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\lib\**" Exclude="libLTO*" TargetPath="tools\$(PackageRID)\lib\%(RecursiveDir)%(Filename)%(Extension)" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\include\**" Exclude="libLTO*" TargetPath="tools\$(PackageRID)\include\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-config" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-dis" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-tblgen" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\lib\**" Exclude="libLTO*" TargetPath="tools\$(PackageTargetRuntime)\lib\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\include\**" Exclude="libLTO*" TargetPath="tools\$(PackageTargetRuntime)\include\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.props
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-config.exe" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-dis.exe" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-tblgen.exe" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\lib\**" Exclude="libLTO*" TargetPath="tools\$(PackageRID)\lib\%(RecursiveDir)%(Filename)%(Extension)" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\include\**" Exclude="libLTO*" TargetPath="tools\$(PackageRID)\include\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-config.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-dis.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-tblgen.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\lib\**" Exclude="libLTO*" TargetPath="tools\$(PackageTargetRuntime)\lib\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\include\**" Exclude="libLTO*" TargetPath="tools\$(PackageTargetRuntime)\include\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt" TargetPath="tools\$(PackageRID)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt" TargetPath="tools\$(PackageRID)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc.exe" TargetPath="tools\$(PackageRID)\bin\" />
-    <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt.exe" TargetPath="tools\$(PackageRID)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
For dumb reasons, our Mac packages are correctly going into osx-10.12-x64, but Windows/Linux into win-amd64 and linux-amd64. This appears to fix the behaviour