### PR TITLE
Re-enable mxe builds for LLVM 9.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,40 +109,40 @@ stages:
           condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
 
       ############ MXE BUILD ############
-#      - job: Build_mxe
-#        displayName: mxe
-#        timeoutInMinutes: 120
-#        strategy:
-#          matrix:
-#            x64:
-#              poolname: Hosted macOS
-#              assetManifestOS: osx
-#              assetManifestPlatform: x64
-#        pool:
-#          name: $(poolname)
-#        steps:
-#        - bash: |
-#            set -exv
-#            git clean -ffdx
-#            git reset --hard HEAD
-#          displayName: 'Clean up working directory'
-#
-#        - bash: |
-#            brew install autoconf automake libtool
-#            brew tap xamarin/xamarin-android-windeps
-#            brew install mingw-w64 xamarin/xamarin-android-windeps/mingw-zlib
-#          displayName: 'Prepare macOS dependencies'
-#
-#        - bash: |
-#            MXE_PREFIX=`brew --prefix`
-#            sed -e "s,@MXE_PATH@,$MXE_PREFIX," < mxe-Win64.cmake.in > llvm/cmake/modules/mxe-Win64.cmake
-#            ./build.sh --ci --restore --build --pack --arch x64-mxe /p:MXE_PREFIX=$MXE_PREFIX -v:normal --configuration $(_BuildConfig) $(_InternalBuildArgs)
-#          displayName: 'Build and package'
-#
-#        - bash:
-#            #./eng/common/build.sh --ci --restore --publish --configuration $(_BuildConfig) $(_InternalBuildArgs) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) --projects $(Build.SourcesDirectory)/llvm.proj
-#          displayName: Publish packages
-#          condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
+      - job: Build_mxe
+        displayName: mxe
+        timeoutInMinutes: 120
+        strategy:
+          matrix:
+            x64:
+              poolname: Hosted macOS
+              assetManifestOS: osx
+              assetManifestPlatform: x64
+        pool:
+          name: $(poolname)
+        steps:
+        - bash: |
+            set -exv
+            git clean -ffdx
+            git reset --hard HEAD
+          displayName: 'Clean up working directory'
+
+        - bash: |
+            brew install autoconf automake libtool
+            brew tap xamarin/xamarin-android-windeps
+            brew install mingw-w64 xamarin/xamarin-android-windeps/mingw-zlib
+          displayName: 'Prepare macOS dependencies'
+
+        - bash: |
+            MXE_PREFIX=`brew --prefix`
+            sed -e "s,@MXE_PATH@,$MXE_PREFIX," < mxe-Win64.cmake.in > llvm/cmake/modules/mxe-Win64.cmake
+            ./build.sh --ci --restore --build --pack --arch x64-mxe /p:MXE_PREFIX=$MXE_PREFIX -v:normal --configuration $(_BuildConfig) $(_InternalBuildArgs)
+          displayName: 'Build and package'
+
+        - bash:
+            #./eng/common/build.sh --ci --restore --publish --configuration $(_BuildConfig) $(_InternalBuildArgs) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) --projects $(Build.SourcesDirectory)/llvm.proj
+          displayName: Publish packages
+          condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
 
       ############ WINDOWS BUILD ############
       - job: Build_Windows

--- a/llvm/lib/ExecutionEngine/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/CMakeLists.txt
@@ -2,6 +2,7 @@ if(NOT LLVM_BUILD_EXECUTION_ENGINE)
     set(EXCLUDE_FROM_ALL ON)
 endif()
 
+if(LLVM_BUILD_EXECUTION_ENGINE)
 add_llvm_library(LLVMExecutionEngine
   ExecutionEngine.cpp
   ExecutionEngineBindings.cpp
@@ -20,7 +21,6 @@ if(BUILD_SHARED_LIBS)
   target_link_libraries(LLVMExecutionEngine PUBLIC LLVMRuntimeDyld)
 endif()
 
-if(LLVM_BUILD_EXECUTION_ENGINE)
 add_subdirectory(Interpreter)
 add_subdirectory(JITLink)
 add_subdirectory(MCJIT)


### PR DESCRIPTION
Right now this is known to fail late in the build due to a linking issue in thread-related code

```
         [ 85%] Linking CXX shared library ../../bin/LLVMCodeGen.dll
         /usr/local/Cellar/mingw-w64/7.0.0_2/toolchain-x86_64/bin/x86_64-w64-mingw32-ld: CMakeFiles/LLVMCodeGen.dir/objects.a(ParallelCG.cpp.obj):ParallelCG.cpp:(.text+0x2b3): undefined reference to `llvm::ThreadPool::ThreadPool(unsigned int)'
         /usr/local/Cellar/mingw-w64/7.0.0_2/toolchain-x86_64/bin/x86_64-w64-mingw32-ld: CMakeFiles/LLVMCodeGen.dir/objects.a(ParallelCG.cpp.obj):ParallelCG.cpp:(.text+0x35c): undefined reference to `llvm::ThreadPool::~ThreadPool()'
         collect2: error: ld returned 1 exit status
```