### PR TITLE
Always include `llvm-as` command in Tools package (6.x)

### DIFF
--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -2,6 +2,7 @@
 <Project>
   <ItemGroup>
     <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-as" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -2,6 +2,7 @@
 <Project>
   <ItemGroup>
     <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-as" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -2,6 +2,7 @@
 <Project>
   <ItemGroup>
     <File Include="..\..\artifacts\tmp\InstallRoot\bin\llc.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="..\..\artifacts\tmp\InstallRoot\bin\llvm-as.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="..\..\artifacts\tmp\InstallRoot\bin\opt.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We need an assembler to turn the output of `llc` into a usable object file, and we should bundle our own rather than assume the OS is providing it.