### PR TITLE
Backport the arm64 part of https://reviews.llvm.org/D71359

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -1961,6 +1961,9 @@ bool AArch64InstrInfo::getMemOperandWithOffset(const MachineInstr &LdSt,
                                           int64_t &Offset,
                                           const TargetRegisterInfo *TRI) const {
   unsigned Width;
+  if (!LdSt.mayLoadOrStore())
+    return false;
+
   return getMemOperandWithOffsetWidth(LdSt, BaseOp, Offset, Width, TRI);
 }
 


### PR DESCRIPTION
See: 870f39d310d6a575fb5d303f4027e988bec9e78e

Fixes a spurious assertion failure seen when compiling arm64 Mono code.