### PR TITLE
RDM and DP detection on arm64 Linux

### DIFF
--- a/llvm/lib/Support/Host.cpp
+++ b/llvm/lib/Support/Host.cpp
@@ -1461,6 +1461,8 @@ bool sys::getHostCPUFeatures(StringMap<bool> &Features) {
     StringRef LLVMFeatureStr = StringSwitch<StringRef>(CPUFeatures[I])
 #if defined(__aarch64__)
                                    .Case("asimd", "neon")
+                                   .Case("asimddp", "dotprod")
+                                   .Case("asimdrdm", "rdm")
                                    .Case("fp", "fp-armv8")
                                    .Case("crc32", "crc")
 #else


### PR DESCRIPTION
There's no guarantee that `ID_AA64ISAR0_EL1` can be read from user-mode,
so add to the existing `/proc/cpuinfo` parser instead.

See also:
- https://www.kernel.org/doc/html/latest/arm64/elf_hwcaps.html
- https://developer.arm.com/documentation/100403/0200/register-descriptions/aarch64-system-registers/id-aa64isar0-el1--aarch64-instruction-set-attribute-register-0--el1
- https://elixir.bootlin.com/linux/v5.11.7/source/arch/arm64/kernel/cpuinfo.c#L58
- https://elixir.bootlin.com/linux/v5.11.7/source/arch/arm64/kernel/cpuinfo.c#L66