### PR TITLE
Build x64 on Ubuntu 18.04, to better align with Wasm

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ stages:
               vmImageName: ubuntu-20.04
               assetManifestOS: linux
               assetManifestPlatform: x64
-              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-crossdeps-20211022152824-8b02f56
               rootfs: 
               archflag: --arch x64
               LLVMTableGenArg: 


### PR DESCRIPTION
This is an alternative fix for the Wasm breakage caused by the Docker update