### PR TITLE
Build Debug packages too

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -181,6 +181,57 @@ stages:
           displayName: Publish packages
           condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
 
+      - job: Build_Windows_Debug
+        displayName: Windows_Debug
+        timeoutInMinutes: 180
+        strategy:
+          matrix:
+            x64:
+              assetManifestOS: win
+              assetManifestPlatform: x64
+              archflag: -arch x64
+              LLVMTableGenArg:
+              ClangTableGenArg:
+            arm64:
+              assetManifestOS: win
+              assetManifestPlatform: arm64
+              archflag: -arch arm64
+              LLVMTableGenArg: /p:LLVMTableGenPath=$(Build.SourcesDirectory)\artifacts\obj\BuildRoot-x64\bin\llvm-tblgen.exe
+              ClangTableGenArg: /p:ClangTableGenPath=$(Build.SourcesDirectory)\artifacts\obj\BuildRoot-x64\bin\clang-tblgen.exe
+            arm:
+              assetManifestOS: win
+              assetManifestPlatform: arm
+              archflag: -arch arm
+              LLVMTableGenArg: /p:LLVMTableGenPath=$(Build.SourcesDirectory)\artifacts\obj\BuildRoot-x64\bin\llvm-tblgen.exe
+              ClangTableGenArg: /p:ClangTableGenPath=$(Build.SourcesDirectory)\artifacts\obj\BuildRoot-x64\bin\clang-tblgen.exe
+        pool:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre
+        steps:
+        - checkout: self
+          clean: true
+          fetchDepth: 2
+
+        - script: |
+            git clean -ffdx
+            git reset --hard HEAD
+          displayName: 'Clean up working directory'
+
+        - powershell: eng\build.ps1 -ci -restore -build -arch x64 -configuration Debug $(_InternalBuildArgs) /p:BuildLLVMTableGenOnly=true
+          displayName: 'Build host llvm-tblgen for cross-compiling'
+          condition: and(succeeded(), ne(variables['assetManifestPlatform'], 'x64'))
+
+        - powershell: eng\build.ps1 -ci -restore -build -pack $(archflag) -configuration Debug $(_InternalBuildArgs) $(LLVMTableGenArg) $(ClangTableGenArg)
+          displayName: 'Build and package'
+
+        - powershell: eng\common\build.ps1 -ci -restore -publish -configuration Debug $(_InternalBuildArgs) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) -projects $(Build.SourcesDirectory)\llvm.proj
+          displayName: Publish packages
+          condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
+
 ############ POST BUILD ARCADE LOGIC ############
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -181,16 +181,6 @@ stages:
           displayName: Publish packages
           condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
 
-  ########## WINDOWS DEBUG BUILD ##########  
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enablePublishBuildArtifacts: true
-      enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
-      variables:
-        - _BuildConfig: Debug
-      jobs:
-
       - job: Build_Windows_Debug
         displayName: Windows_Debug
         timeoutInMinutes: 180
@@ -231,14 +221,14 @@ stages:
             git reset --hard HEAD
           displayName: 'Clean up working directory'
 
-        - powershell: eng\build.ps1 -ci -restore -build -arch x64 -configuration $(_BuildConfig) $(_InternalBuildArgs) /p:BuildLLVMTableGenOnly=true
+        - powershell: eng\build.ps1 -ci -restore -build -arch x64 -configuration Debug $(_InternalBuildArgs) /p:BuildLLVMTableGenOnly=true
           displayName: 'Build host llvm-tblgen for cross-compiling'
           condition: and(succeeded(), ne(variables['assetManifestPlatform'], 'x64'))
 
-        - powershell: eng\build.ps1 -ci -restore -build -pack $(archflag) -configuration $(_BuildConfig) $(_InternalBuildArgs) $(LLVMTableGenArg) $(ClangTableGenArg)
+        - powershell: eng\build.ps1 -ci -restore -build -pack $(archflag) -configuration Debug $(_InternalBuildArgs) $(LLVMTableGenArg) $(ClangTableGenArg)
           displayName: 'Build and package'
 
-        - powershell: eng\common\build.ps1 -ci -restore -publish -configuration $(_BuildConfig) $(_InternalBuildArgs) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) -projects $(Build.SourcesDirectory)\llvm.proj
+        - powershell: eng\common\build.ps1 -ci -restore -publish -configuration Debug $(_InternalBuildArgs) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) -projects $(Build.SourcesDirectory)\llvm.proj
           displayName: Publish packages
           condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
 

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -181,6 +181,16 @@ stages:
           displayName: Publish packages
           condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
 
+  ########## WINDOWS DEBUG BUILD ##########  
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enablePublishBuildArtifacts: true
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: true
+      variables:
+        - _BuildConfig: Debug
+      jobs:
+
       - job: Build_Windows_Debug
         displayName: Windows_Debug
         timeoutInMinutes: 180
@@ -221,14 +231,14 @@ stages:
             git reset --hard HEAD
           displayName: 'Clean up working directory'
 
-        - powershell: eng\build.ps1 -ci -restore -build -arch x64 -configuration Debug $(_InternalBuildArgs) /p:BuildLLVMTableGenOnly=true
+        - powershell: eng\build.ps1 -ci -restore -build -arch x64 -configuration $(_BuildConfig) $(_InternalBuildArgs) /p:BuildLLVMTableGenOnly=true
           displayName: 'Build host llvm-tblgen for cross-compiling'
           condition: and(succeeded(), ne(variables['assetManifestPlatform'], 'x64'))
 
-        - powershell: eng\build.ps1 -ci -restore -build -pack $(archflag) -configuration Debug $(_InternalBuildArgs) $(LLVMTableGenArg) $(ClangTableGenArg)
+        - powershell: eng\build.ps1 -ci -restore -build -pack $(archflag) -configuration $(_BuildConfig) $(_InternalBuildArgs) $(LLVMTableGenArg) $(ClangTableGenArg)
           displayName: 'Build and package'
 
-        - powershell: eng\common\build.ps1 -ci -restore -publish -configuration Debug $(_InternalBuildArgs) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) -projects $(Build.SourcesDirectory)\llvm.proj
+        - powershell: eng\common\build.ps1 -ci -restore -publish -configuration $(_BuildConfig) $(_InternalBuildArgs) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) -projects $(Build.SourcesDirectory)\llvm.proj
           displayName: Publish packages
           condition: and(succeeded(), ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'))
 

--- a/llvm.proj
+++ b/llvm.proj
@@ -140,4 +140,3 @@
     <MSBuild Projects="nuget/packages.builds" Targets="Build" />
   </Target>
 </Project>
-

--- a/llvm.proj
+++ b/llvm.proj
@@ -51,7 +51,7 @@
     <_LLVMBuildArgs Condition="('$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64') and '$(BuildOS)' == 'Linux'" Include="-DCMAKE_SYSTEM_NAME=Linux" />
     <_LLVMBuildArgs Condition="'$(LLVMTableGenPath)' != ''" Include='-DLLVM_TABLEGEN="$(LLVMTableGenPath)"' />
     <_LLVMBuildArgs Condition="'$(ClangTableGenPath)' != ''" Include='-DCLANG_TABLEGEN="$(ClangTableGenPath)"' />
-    <_LLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=$(Configuration)" />
+    <_LLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=Release" />
     <_LLVMBuildArgs Include="-DLLVM_BUILD_LLVM_C_DYLIB=OFF" />
     <_LLVMBuildArgs Include="-DLLVM_ENABLE_DIA_SDK=OFF" />
     <_LLVMBuildArgs Include="-DLLVM_INCLUDE_TESTS=OFF" />
@@ -67,8 +67,10 @@
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_PDB=ON' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dbg' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dwarf -DLLVM_EXTERNALIZE_DEBUGINFO_FLATTEN=ON' />
-    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_USE_CRT_DEBUG=MT' />
-    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_USE_CRT_RELEASE=MT' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT' and '$(Configuration)' == 'Release'" Include='-DLLVM_USE_CRT_DEBUG=MT' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT' and '$(Configuration)' == 'Release'" Include='-DLLVM_USE_CRT_RELEASE=MT' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT' and '$(Configuration)' == 'Debug'" Include='-DLLVM_USE_CRT_DEBUG=MTd' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT' and '$(Configuration)' == 'Debug'" Include='-DLLVM_USE_CRT_RELEASE=MTd' />
   </ItemGroup>
 
   <ItemGroup>

--- a/llvm.proj
+++ b/llvm.proj
@@ -129,6 +129,8 @@
       <FilesToDelete Include="$(_LLVMInstallDir)/lib/libLTO*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/lib/LLVMHello*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/lib/BugpointPasses.*" />
+      <FilesToDelete Include="$(_LLVMInstallDir)/lib/clang*" />
+      <FilesToDelete Include="$(_LLVMInstallDir)/bin/clang-*" />
     </ItemGroup>
     <Delete Files="@(FilesToDelete)" ContinueOnError="true" TreatErrorsAsWarnings="true" />
   </Target>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.Debug.builds
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.Debug.builds
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.Build.Traversal">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(builds.targets))" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.Debug.pkgproj
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk/Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.Debug.pkgproj
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <Import Condition="'$(_packageTargetOSGroup)' != ''"  Project="$(MSBuildThisFileDirectory)runtime.$(_packageTargetOSGroup).$(MSBuildProjectName.Substring(0, $(MSBuildProjectName.LastIndexOf('.')))).props" />
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/Microsoft.NETCore.Runtime.Mono.LLVM.Tools.Debug.builds
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/Microsoft.NETCore.Runtime.Mono.LLVM.Tools.Debug.builds
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.Build.Traversal">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(builds.targets))" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/Microsoft.NETCore.Runtime.Mono.LLVM.Tools.Debug.pkgproj
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/Microsoft.NETCore.Runtime.Mono.LLVM.Tools.Debug.pkgproj
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <Import Condition="'$(_packageTargetOSGroup)' != ''"  Project="$(MSBuildThisFileDirectory)runtime.$(_packageTargetOSGroup).$(MSBuildProjectName.Substring(0, $(MSBuildProjectName.LastIndexOf('.')))).props" />
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/nuget/descriptions.json
+++ b/nuget/descriptions.json
@@ -15,8 +15,18 @@
         "CommonTypes": [ ]
     },
     {
+        "Name": "Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.Debug",
+        "Description": "The .NET Core fork of the LLVM project, used to compile the Mono .NET Core runtime in LLVM JIT mode (Debug runtime). Internal implementation package not meant for direct consumption.  Please do not reference directly.",
+        "CommonTypes": [ ]
+    },
+    {
         "Name": "Microsoft.NETCore.Runtime.Mono.LLVM.Tools",
         "Description": "The llvm-as, llc and opt tools, used by the Mono .NET Core runtime in LLVM AOT mode.",
+        "CommonTypes": [ ]
+    },
+    {
+        "Name": "Microsoft.NETCore.Runtime.Mono.LLVM.Tools.Debug",
+        "Description": "The llvm-as, llc and opt tools, used by the Mono .NET Core runtime in LLVM AOT mode (Debug runtime).",
         "CommonTypes": [ ]
     }
 ]

--- a/nuget/packages.builds
+++ b/nuget/packages.builds
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="Microsoft.NETCore.Runtime.Mono.LLVM.Sdk\Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.builds" />
-    <ProjectReference Include="Microsoft.NETCore.Runtime.Mono.LLVM.Tools\Microsoft.NETCore.Runtime.Mono.LLVM.Tools.builds" />
+    <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Sdk\Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.builds" />
+    <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Tools\Microsoft.NETCore.Runtime.Mono.LLVM.Tools.builds" />
+    <ProjectReference Condition="'$(Configuration)' == 'Debug'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Sdk\Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.Debug.builds" />
+    <ProjectReference Condition="'$(Configuration)' == 'Debug'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Tools\Microsoft.NETCore.Runtime.Mono.LLVM.Tools.Debug.builds" />
   </ItemGroup>
 
   <!-- Generate a version.txt file we include in our packages


### PR DESCRIPTION
This introduces an extra set of Debug-suffixed packages, with debug builds of the LLVM components. This is needed primarily for Windows, because Windows links a different libc depending on whether you build Debug or Release configuration (so we cannot build Debug Mono linked against LLVM, unless the LLVM is also Debug)