### PR TITLE
Fix dev machine local windows build

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -14,11 +14,14 @@
     set VS_VCINSTALL_DIR=
 
     :: Try to locate installed VisualStudio VC environment.
-    if exist "%VSWHERE_TOOLS_BIN%" (
+    if "%VCINSTALLDIR%" == "" if exist "%VSWHERE_TOOLS_BIN%" (
         for /f "tokens=*" %%a in ('"%VSWHERE_TOOLS_BIN%" -latest -property installationPath') do (
             set VS_VCINSTALL_DIR=%%a\VC\
         )
     )
+
+    if NOT "%VCINSTALLDIR%" == "" set VS_VCINSTALL_DIR=%VCINSTALLDIR%
+
     :: Run VS build environment script.
     call "%VS_VCINSTALL_DIR%\Auxiliary\Build\$(_VCVarsScriptName)"
 


### PR DESCRIPTION
This fixes this error, where it mixed 2019 and 2022 VS installations:

    **********************************************************************
    ** Visual Studio 2019 Developer Command Prompt v16.11.3
    ** Copyright (c) 2021 Microsoft Corporation
    **********************************************************************
    [ERROR:devinit.bat] File not found : "C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\Tools\devinit\devinit.exe"
    [ERROR:VsDevCmd.bat] *** VsDevCmd.bat encountered errors. Environment may be incomplete and/or incorrect. ***
    [ERROR:VsDevCmd.bat] In an uninitialized command prompt, please 'set VSCMD_DEBUG=[value]' and then re-run
    [ERROR:VsDevCmd.bat] vsdevcmd.bat [args] for additional details.
    [ERROR:VsDevCmd.bat] Where [value] is:
    [ERROR:VsDevCmd.bat]    1 : basic debug logging
    [ERROR:VsDevCmd.bat]    2 : detailed debug logging
    [ERROR:VsDevCmd.bat]    3 : trace level logging. Redirection of output to a file when using this level is recommended.
    [ERROR:VsDevCmd.bat] Example: set VSCMD_DEBUG=3
    [ERROR:VsDevCmd.bat]          vsdevcmd.bat > vsdevcmd.trace.txt 2>&1