### PR TITLE
Pass --build-id to linker

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -76,6 +76,7 @@
     <_LLVMBuildArgs Include='-DCLANG_INCLUDE_TESTS:BOOL=OFF' />
     <_LLVMBuildArgs Include='-DCLANG_ENABLE_ARCMT:BOOL=OFF' />
     <_LLVMBuildArgs Include='-DCLANG_ENABLE_STATIC_ANALYZER:BOOL=OFF' />
+    <_LLVMBuildArgs Include='-DENABLE_LINKER_BUILD_ID:BOOL=ON' />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildOS)' != 'Windows_NT'">


### PR DESCRIPTION
That should fix these errors:

    Publishing symbol file runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.11.1.0-alpha.1.21620.1.symbols.nupkg to https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection:
    D:\a\1\s\.packages\microsoft.dotnet.arcade.sdk\7.0.0-beta.21617.4\tools\SdkTasks\PublishArtifactsInManifest.proj(144,5): error : Invalid ELF BuildID '<null>' for tools/linux-x64/lib/libclang-cpp.so
    ##[error].packages\microsoft.dotnet.arcade.sdk\7.0.0-beta.21617.4\tools\SdkTasks\PublishArtifactsInManifest.proj(144,5): error : Invalid ELF BuildID '<null>' for tools/linux-x64/lib/libclang-cpp.so
    D:\a\1\s\.packages\microsoft.dotnet.arcade.sdk\7.0.0-beta.21617.4\tools\SdkTasks\PublishArtifactsInManifest.proj(144,5): error : Invalid ELF BuildID '<null>' for tools/linux-x64/lib/libclang.so
    ##[error].packages\microsoft.dotnet.arcade.sdk\7.0.0-beta.21617.4\tools\SdkTasks\PublishArtifactsInManifest.proj(144,5): error : Invalid ELF BuildID '<null>' for tools/linux-x64/lib/libclang.so