### PR TITLE
Add `.note.GNU-stack` section to produced executables

### DIFF
--- a/llvm/tools/objwriter/objwriter.cpp
+++ b/llvm/tools/objwriter/objwriter.cpp
@@ -147,6 +147,7 @@ bool ObjectWriter::Init(llvm::StringRef ObjectFilePath, const char* tripleName) 
       /*DWARFMustBeAtTheEnd*/ false);
   if (!Streamer)
     return error("no object streamer for target " + TripleName);
+  Streamer->InitSections(/* NoExecStack */ true);
   Assembler = &Streamer->getAssembler();
 
   FrameOpened = false;


### PR DESCRIPTION
Do this unconditionally because there's no scenario where we would need executable stack for managed code.