### PR TITLE
Remove Darwin workaround

### DIFF
--- a/llvm/tools/objwriter/objwriter.cpp
+++ b/llvm/tools/objwriter/objwriter.cpp
@@ -67,19 +67,6 @@ void ObjectWriter::InitTripleName(const char* tripleName) {
   TripleName = tripleName != nullptr ? tripleName : sys::getDefaultTargetTriple();
 }
 
-Triple ObjectWriter::GetTriple() {
-  Triple TheTriple(TripleName);
-
-  if (TheTriple.getOS() == Triple::OSType::Darwin) {
-    TheTriple = Triple(
-        TheTriple.getArchName(), TheTriple.getVendorName(), "darwin",
-        TheTriple
-            .getEnvironmentName()); // it is workaround for llvm bug
-                                    // https://bugs.llvm.org//show_bug.cgi?id=24927.
-  }
-  return TheTriple;
-}
-
 bool ObjectWriter::Init(llvm::StringRef ObjectFilePath, const char* tripleName) {
   llvm_shutdown_obj Y; // Call llvm_shutdown() on exit.
 
@@ -88,7 +75,7 @@ bool ObjectWriter::Init(llvm::StringRef ObjectFilePath, const char* tripleName) 
   InitializeAllTargetMCs();
 
   InitTripleName(tripleName);
-  Triple TheTriple = GetTriple();
+  Triple TheTriple(TripleName);
 
   // Get the target specific parser.
   std::string TargetError;

--- a/llvm/tools/objwriter/objwriter.h
+++ b/llvm/tools/objwriter/objwriter.h
@@ -157,7 +157,6 @@ private:
   void EmitCVUserDefinedTypesSymbols();
 
   void InitTripleName(const char* tripleName = nullptr);
-  Triple GetTriple();
   unsigned GetDFSize();
   void EmitRelocDirective(const int Offset, StringRef Name, const MCExpr *Expr);
   const MCExpr *GenTargetExpr(const MCSymbol* Symbol,


### PR DESCRIPTION
This caught my attention as I was looking at the ObjWriter. LLVM no longer emits a `LC_VERSION_MIN_MACOSX` load command unless we explicitly set a version. I don't see a difference in `llvm-objdump -macho -x foo.o` with/without these lines (I didn't bother myself to boot into macOS to run `otool`).