### PR TITLE
Fix llvm-dwarfdump warnings

### DIFF
--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfAbbrev.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfAbbrev.cpp
@@ -125,6 +125,17 @@ void Dump(MCObjectStreamer *Streamer, uint16_t DwarfVersion, unsigned TargetPoin
         dwarf::DW_AT_declaration, dwarf::DW_FORM_flag_present,
         0, 0,
 
+    SubprogramStaticNoChildrenSpec,
+        dwarf::DW_TAG_subprogram, dwarf::DW_CHILDREN_no,
+        dwarf::DW_AT_name, dwarf::DW_FORM_strp,
+        dwarf::DW_AT_linkage_name, dwarf::DW_FORM_strp,
+        dwarf::DW_AT_decl_file, dwarf::DW_FORM_data1,
+        dwarf::DW_AT_decl_line, dwarf::DW_FORM_data1,
+        dwarf::DW_AT_type, dwarf::DW_FORM_ref4,
+        dwarf::DW_AT_external, dwarf::DW_FORM_flag_present,
+        dwarf::DW_AT_declaration, dwarf::DW_FORM_flag_present,
+        0, 0,
+
     Variable,
         dwarf::DW_TAG_variable, dwarf::DW_CHILDREN_no,
         dwarf::DW_AT_name, dwarf::DW_FORM_strp,

--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfAbbrev.h
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfAbbrev.h
@@ -30,6 +30,7 @@ enum DwarfAbbrev : uint16_t
   SubprogramStatic,
   SubprogramSpec,
   SubprogramStaticSpec,
+  SubprogramStaticNoChildrenSpec,
   Variable,
   VariableLoc,
   VariableStatic,

--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfTypeBuilder.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfTypeBuilder.cpp
@@ -601,8 +601,12 @@ void DwarfMemberFunctionIdTypeInfo::DumpStrings(MCObjectStreamer *Streamer) {
 void DwarfMemberFunctionIdTypeInfo::DumpTypeInfo(MCObjectStreamer *Streamer, UserDefinedDwarfTypesBuilder *TypeBuilder) {
   // Abbrev Number
   bool IsStatic = MemberFunctionTypeInfo->IsStatic();
+  bool HasParameters = MemberFunctionTypeInfo->GetArgTypes().size();
 
-  Streamer->emitULEB128IntValue(IsStatic ? DwarfAbbrev::SubprogramStaticSpec : DwarfAbbrev::SubprogramSpec);
+  Streamer->emitULEB128IntValue(
+      IsStatic ? (HasParameters ? DwarfAbbrev::SubprogramStaticSpec
+                                : DwarfAbbrev::SubprogramStaticNoChildrenSpec)
+               : DwarfAbbrev::SubprogramSpec);
 
   // DW_AT_name
   EmitSectionOffset(Streamer, StrSymbol, 4);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/72552. No warnings left with llvm-dwarfdump from LLVM 12.