### PR TITLE
Don't set CMAKE_CROSSCOMPILING for arm64/arm cross-compiling

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -33,8 +33,6 @@
     <_CMakeInstallCommand>$(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -P cmake_install.cmake</_CMakeInstallCommand>
   </PropertyGroup>
 
-<!---DLLVM_TABLEGEN=C:\Users\Alexander\Desktop\llvm-project\build-x64\bin\llvm-tblgen.exe-->
-
   <ItemGroup>
     <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm64'" Include="-DLLVM_TARGET_ARCH=AARCH64" />
     <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm'" Include="-DLLVM_TARGET_ARCH=ARM" />
@@ -54,31 +52,31 @@
     <_LLVMBuildArgs Condition="'$(LLVMTableGenPath)' != ''" Include='-DLLVM_TABLEGEN="$(LLVMTableGenPath)"' />
     <_LLVMBuildArgs Condition="'$(ClangTableGenPath)' != ''" Include='-DCLANG_TABLEGEN="$(ClangTableGenPath)"' />
     <_LLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=$(Configuration)" />
-    <_LLVMBuildArgs Include="-DLLVM_BUILD_LLVM_C_DYLIB:BOOL=OFF" />
-    <_LLVMBuildArgs Include="-DLLVM_ENABLE_DIA_SDK:BOOL=OFF" />
-    <_LLVMBuildArgs Include="-DLLVM_INCLUDE_TESTS:BOOL=OFF" />
+    <_LLVMBuildArgs Include="-DLLVM_BUILD_LLVM_C_DYLIB=OFF" />
+    <_LLVMBuildArgs Include="-DLLVM_ENABLE_DIA_SDK=OFF" />
+    <_LLVMBuildArgs Include="-DLLVM_INCLUDE_TESTS=OFF" />
     <_LLVMBuildArgs Include='-DLLVM_TARGETS_TO_BUILD="X86%3BAArch64%3BARM"' />
-    <_LLVMBuildArgs Include='-DLLVM_BUILD_TESTS:BOOL=OFF' />
-    <_LLVMBuildArgs Include='-DLLVM_BUILD_EXAMPLES:BOOL=OFF' />
-    <_LLVMBuildArgs Include='-DLLVM_INCLUDE_EXAMPLES:BOOL=OFF' />
+    <_LLVMBuildArgs Include='-DLLVM_BUILD_TESTS=OFF' />
+    <_LLVMBuildArgs Include='-DLLVM_BUILD_EXAMPLES=OFF' />
+    <_LLVMBuildArgs Include='-DLLVM_INCLUDE_EXAMPLES=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_TOOLS_TO_BUILD="opt%3Bllc%3Bllvm-config%3Bllvm-dis%3Bllvm-mc%3Bllvm-as"' />
-    <_LLVMBuildArgs Include='-DLLVM_ENABLE_LIBXML2:BOOL=OFF' />
-    <_LLVMBuildArgs Include='-DLLVM_ENABLE_TERMINFO:BOOL=OFF' />
-    <_LLVMBuildArgs Include='-DLLVM_EXTERNALIZE_DEBUGINFO:BOOL=ON' />
-    <_LLVMBuildArgs Include='-DLLVM_EXTERNALIZE_DEBUGINFO_INSTALL:BOOL=ON' />
-    <_LLVMBuildArgs Include='-DLLVM_ENABLE_PDB:BOOL=ON' />
+    <_LLVMBuildArgs Include='-DLLVM_ENABLE_LIBXML2=OFF' />
+    <_LLVMBuildArgs Include='-DLLVM_ENABLE_TERMINFO=OFF' />
+    <_LLVMBuildArgs Include='-DLLVM_EXTERNALIZE_DEBUGINFO=ON' />
+    <_LLVMBuildArgs Include='-DLLVM_EXTERNALIZE_DEBUGINFO_INSTALL=ON' />
+    <_LLVMBuildArgs Include='-DLLVM_ENABLE_PDB=ON' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dbg' />
-    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dwarf -DLLVM_EXTERNALIZE_DEBUGINFO_FLATTEN:BOOL=ON' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dwarf -DLLVM_EXTERNALIZE_DEBUGINFO_FLATTEN=ON' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_USE_CRT_DEBUG=MT' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_USE_CRT_RELEASE=MT' />
   </ItemGroup>
 
   <ItemGroup>
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_PROJECTS=clang' />
-    <_LLVMBuildArgs Include='-DCLANG_BUILD_TOOLS:BOOL=OFF' />
-    <_LLVMBuildArgs Include='-DCLANG_INCLUDE_TESTS:BOOL=OFF' />
-    <_LLVMBuildArgs Include='-DCLANG_ENABLE_ARCMT:BOOL=OFF' />
-    <_LLVMBuildArgs Include='-DCLANG_ENABLE_STATIC_ANALYZER:BOOL=OFF' />
+    <_LLVMBuildArgs Include='-DCLANG_BUILD_TOOLS=OFF' />
+    <_LLVMBuildArgs Include='-DCLANG_INCLUDE_TESTS=OFF' />
+    <_LLVMBuildArgs Include='-DCLANG_ENABLE_ARCMT=OFF' />
+    <_LLVMBuildArgs Include='-DCLANG_ENABLE_STATIC_ANALYZER=OFF' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux'" Include='-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--build-id' />
   </ItemGroup>
 

--- a/llvm.proj
+++ b/llvm.proj
@@ -48,7 +48,9 @@
     <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildOS)' == 'Linux'" Include="-DCMAKE_STRIP=/usr/bin/arm-linux-gnueabihf-strip" />
     <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildOS)' == 'OSX'" Include="-DLLVM_DEFAULT_TARGET_TRIPLE=arm64-apple-darwin" />
     <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildOS)' == 'OSX'" Include="-DCMAKE_OSX_ARCHITECTURES=arm64"/>
-    <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'" Include="-DCMAKE_CROSSCOMPILING:BOOL=ON" />
+    <!-- Enable CMake cross-compilation support by setting CMAKE_SYSTEM_NAME manually, see https://github.com/llvm/llvm-project/issues/52819 -->
+    <_LLVMBuildArgs Condition="('$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64') and '$(BuildOS)' == 'Windows_NT'" Include="-DCMAKE_SYSTEM_NAME=Windows" />
+    <_LLVMBuildArgs Condition="('$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64') and '$(BuildOS)' == 'Linux'" Include="-DCMAKE_SYSTEM_NAME=Linux" />
     <_LLVMBuildArgs Condition="'$(LLVMTableGenPath)' != ''" Include='-DLLVM_TABLEGEN="$(LLVMTableGenPath)"' />
     <_LLVMBuildArgs Condition="'$(ClangTableGenPath)' != ''" Include='-DCLANG_TABLEGEN="$(ClangTableGenPath)"' />
     <_LLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=$(Configuration)" />

--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -85,6 +85,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         ${external_project_source_dirs}
         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
         -DLLVM_TOOLS_TO_BUILD="all"
+        -DLLVM_INCLUDE_TESTS=OFF
         ${build_type_flags} ${linker_flag} ${external_clang_dir}
         ${ARGN}
     WORKING_DIRECTORY ${${project_name}_${target_name}_BUILD}


### PR DESCRIPTION
We're not supposed to set it manually, CMake will set it based on the CMAKE_SYSTEM_NAME.
See https://github.com/llvm/llvm-project/issues/52819 where the llvm docs were updated to recommend setting CMAKE_SYSTEM_NAME instead of CMAKE_CROSSCOMPILING when cross-compiling
