### PR TITLE
Move pipeline definition to /eng

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
     - objwriter/12.x
 
 variables:
-- template: eng/common-variables.yml
+- template: /eng/common-variables.yml
 
 stages:
 - stage: build


### PR DESCRIPTION
This is likely the reason why we don't get official builds anymore. Apparently, the repo moved the path where the YAML is.