### PR TITLE
Add a parameter to force use of devtoolset7 and consume it

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
             x64:
               assetManifestOS: linux
               assetManifestPlatform: x64
-              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20220716123527-d0bc8ed
               rootfs: 
               archflag: --arch x64
               LLVMTableGenArg: 

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -41,6 +41,7 @@ stages:
               archflag: --arch x64
               LLVMTableGenArg: 
               ClangTableGenArg: 
+              Devtoolset7Arg: /p:ForceDevtoolset7=true
             arm64:
               assetManifestOS: linux
               assetManifestPlatform: arm64
@@ -49,6 +50,7 @@ stages:
               archflag: --arch arm64
               LLVMTableGenArg: /p:LLVMTableGenPath=$(Build.SourcesDirectory)/artifacts/obj/BuildRoot-x64/bin/llvm-tblgen
               ClangTableGenArg: /p:ClangTableGenPath=$(Build.SourcesDirectory)/artifacts/obj/BuildRoot-x64/bin/clang-tblgen
+              Devtoolset7Arg: 
             arm:
               assetManifestOS: linux
               assetManifestPlatform: arm
@@ -57,6 +59,7 @@ stages:
               archflag: --arch arm
               LLVMTableGenArg: /p:LLVMTableGenPath=$(Build.SourcesDirectory)/artifacts/obj/BuildRoot-x64/bin/llvm-tblgen
               ClangTableGenArg: /p:ClangTableGenPath=$(Build.SourcesDirectory)/artifacts/obj/BuildRoot-x64/bin/clang-tblgen
+              Devtoolset7Arg: 
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             vmImage: ubuntu-20.04
@@ -78,7 +81,7 @@ stages:
           condition: and(succeeded(), ne(variables['assetManifestPlatform'], 'x64'))
 
         - bash: |
-            ./build.sh --ci --restore --build --pack $(archflag) --configuration $(_BuildConfig) $(_InternalBuildArgs) $(LLVMTableGenArg) $(ClangTableGenArg)
+            ./build.sh --ci --restore --build --pack $(archflag) --configuration $(_BuildConfig) $(_InternalBuildArgs) $(LLVMTableGenArg) $(ClangTableGenArg) $(Devtoolset7Arg)
           displayName: 'Build and package'
           env:
             ROOTFS_DIR: $(rootfs)

--- a/llvm.proj
+++ b/llvm.proj
@@ -33,6 +33,11 @@
     <_CMakeInstallCommand>$(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -P cmake_install.cmake</_CMakeInstallCommand>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ForceDevtoolset7)' == 'true'">
+    <Devtoolset7LinkFlag>-L/opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/</Devtoolset7LinkFlag>
+    <Devtoolset7CompileFlag>--gcc-toolchain=/opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/ -I/opt/rh/devtoolset-7/root/usr/include/c++/7/ -I/opt/rh/devtoolset-7/root/usr/include/c++/7/x86_64-redhat-linux/ -B/opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/</Devtoolset7CompileFlag>
+  </PropertyGroup>
+
   <ItemGroup>
     <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm64'" Include="-DLLVM_TARGET_ARCH=AARCH64" />
     <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm'" Include="-DLLVM_TARGET_ARCH=ARM" />
@@ -77,7 +82,8 @@
     <_LLVMBuildArgs Include='-DCLANG_INCLUDE_TESTS=OFF' />
     <_LLVMBuildArgs Include='-DCLANG_ENABLE_ARCMT=OFF' />
     <_LLVMBuildArgs Include='-DCLANG_ENABLE_STATIC_ANALYZER=OFF' />
-    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux'" Include='-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--build-id' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux'" Include='-DCMAKE_SHARED_LINKER_FLAGS="$(Devtoolset7LinkFlag) -Wl,--build-id"' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux'" Include='-DCMAKE_MODULE_LINKER_FLAGS="$(Devtoolset7LinkFlag) -Wl,--build-id"' />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildOS)' != 'Windows_NT'">
@@ -97,8 +103,8 @@
 
   <ItemGroup Condition="'$(BuildOS)' != 'Windows_NT'">
     <_LLVMBuildArgs Include='-DCMAKE_C_FLAGS="-I../llvm/include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CrossCFlags)"' />
-    <_LLVMBuildArgs Include='-DCMAKE_CXX_FLAGS="-I../llvm/include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CrossCFlags) "' />
-    <_LLVMBuildArgs Include='-DCMAKE_EXE_LINKER_FLAGS="$(_ExeLinkerFlags)"' />
+    <_LLVMBuildArgs Include='-DCMAKE_CXX_FLAGS="-I../llvm/include $(Devtoolset7CompileFlag) -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CrossCFlags) "' />
+    <_LLVMBuildArgs Include='-DCMAKE_EXE_LINKER_FLAGS="$(Devtoolset7LinkFlag) $(_ExeLinkerFlags)"' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64'" Include='-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX' and '$(TargetArchitecture)' == 'x64'" Include='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13' />
   </ItemGroup>

--- a/llvm.proj
+++ b/llvm.proj
@@ -34,8 +34,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ForceDevtoolset7)' == 'true'">
-    <Devtoolset7LinkFlag>-L/opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/</Devtoolset7LinkFlag>
-    <Devtoolset7CompileFlag>--gcc-toolchain=/opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/ -I/opt/rh/devtoolset-7/root/usr/include/c++/7/ -I/opt/rh/devtoolset-7/root/usr/include/c++/7/x86_64-redhat-linux/ -B/opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/</Devtoolset7CompileFlag>
+    <DevtoolsetRoot>/opt/rh/devtoolset-7/root</DevtoolsetRoot>
+    <Devtoolset7LinkFlag>-L$(DevtoolsetRoot)/usr/lib/gcc/x86_64-redhat-linux/7/</Devtoolset7LinkFlag>
+    <Devtoolset7CompileFlag>--gcc-toolchain=$(DevtoolsetRoot)/usr/lib/gcc/x86_64-redhat-linux/7/ -I$(DevtoolsetRoot)/usr/include/c++/7/ -I$(DevtoolsetRoot)/usr/include/c++/7/x86_64-redhat-linux/ -B$(DevtoolsetRoot)/usr/lib/gcc/x86_64-redhat-linux/7/</Devtoolset7CompileFlag>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Force use of Devtoolset 7 for x64 builds, to resolve problem where libs built with Devtoolset 9 cannot be linked on Ubuntu 18.04 based cross compiler VMs (e.g. Browser-wasm branch of runtime)