### PR TITLE
Add support for setting the copyright on produced binaries

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -156,10 +156,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore1ESPool-Public
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre
+            demands: ImageOverride -equals Build.Windows.Amd64.VS2022
         steps:
         - script: |
             git clean -ffdx

--- a/llvm.proj
+++ b/llvm.proj
@@ -52,6 +52,7 @@
     <_LLVMBuildArgs Condition="'$(LLVMTableGenPath)' != ''" Include='-DLLVM_TABLEGEN="$(LLVMTableGenPath)"' />
     <_LLVMBuildArgs Condition="'$(ClangTableGenPath)' != ''" Include='-DCLANG_TABLEGEN="$(ClangTableGenPath)"' />
     <_LLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=$(Configuration)" />
+    <_LLVMBuildArgs Include='-DLEGAL_COPYRIGHT:STRING="\xa9 Microsoft Corporation. All rights reserved."' />
     <_LLVMBuildArgs Include="-DLLVM_BUILD_LLVM_C_DYLIB:BOOL=OFF" />
     <_LLVMBuildArgs Include="-DLLVM_ENABLE_DIA_SDK:BOOL=OFF" />
     <_LLVMBuildArgs Include="-DLLVM_INCLUDE_TESTS:BOOL=OFF" />
@@ -138,4 +139,3 @@
     <MSBuild Projects="nuget/packages.builds" Targets="Build" />
   </Target>
 </Project>
-

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -344,11 +344,13 @@ endfunction(add_windows_version_resource_file)
 #     Optional version string (defaults to PACKAGE_VERSION)
 #   PRODUCT_NAME
 #     Optional product name string (defaults to "LLVM")
+#   PRODUCT_LEGAL_COPYRIGHT
+#     Optional product legal copyright string
 #   )
 function(set_windows_version_resource_properties name resource_file)
   cmake_parse_arguments(ARG
     ""
-    "VERSION_MAJOR;VERSION_MINOR;VERSION_PATCHLEVEL;VERSION_STRING;PRODUCT_NAME"
+    "VERSION_MAJOR;VERSION_MINOR;VERSION_PATCHLEVEL;VERSION_STRING;PRODUCT_NAME;PRODUCT_LEGAL_COPYRIGHT"
     ""
     ${ARGN})
 
@@ -372,6 +374,10 @@ function(set_windows_version_resource_properties name resource_file)
     set(ARG_PRODUCT_NAME "LLVM")
   endif()
 
+  if (NOT DEFINED ARG_PRODUCT_LEGAL_COPYRIGHT)
+    set(ARG_PRODUCT_LEGAL_COPYRIGHT ${LEGAL_COPYRIGHT})
+  endif()
+
   set_property(SOURCE ${resource_file}
                PROPERTY COMPILE_FLAGS /nologo)
   set_property(SOURCE ${resource_file}
@@ -383,7 +389,8 @@ function(set_windows_version_resource_properties name resource_file)
                "RC_FILE_VERSION=\"${ARG_VERSION_STRING}\""
                "RC_INTERNAL_NAME=\"${name}\""
                "RC_PRODUCT_NAME=\"${ARG_PRODUCT_NAME}\""
-               "RC_PRODUCT_VERSION=\"${ARG_VERSION_STRING}\"")
+               "RC_PRODUCT_VERSION=\"${ARG_VERSION_STRING}\""
+               "RC_COPYRIGHT=\"${ARG_PRODUCT_LEGAL_COPYRIGHT}\"")
 endfunction(set_windows_version_resource_properties)
 
 # llvm_add_library(name sources...


### PR DESCRIPTION
It was not possible to set the copyright string for binaries. The RC_COPYRIGHT string in the windows resource definition would always be empty. Plumb this value through and set it explicitly in our CMAKE options.