### PR TITLE
Add support for setting the copyright on produced binaries

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -41,6 +41,7 @@
     <_LLVMBuildArgs Condition="'$(LLVMTableGenPath)' != ''" Include='-DLLVM_TABLEGEN="$(LLVMTableGenPath)"' />
     <_LLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=$(Configuration)" />
     <_LLVMBuildArgs Include='-DLLVM_BUILD_TOOLS:BOOL=OFF' />
+    <_LLVMBuildArgs Include='-DLEGAL_COPYRIGHT:STRING="\xa9 Microsoft Corporation. All rights reserved."' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_TERMINFO:BOOL=OFF' />
     <_LLVMBuildArgs Include="-DLLVM_INCLUDE_UTILS:BOOL=OFF" />
     <_LLVMBuildArgs Include="-DLLVM_INCLUDE_RUNTIMES:BOOL=OFF" />
@@ -113,4 +114,3 @@
     <MSBuild Projects="nuget/packages.builds" Targets="Build" />
   </Target>
 </Project>
-

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -334,11 +334,13 @@ endfunction(add_windows_version_resource_file)
 #     Optional version string (defaults to PACKAGE_VERSION)
 #   PRODUCT_NAME
 #     Optional product name string (defaults to "LLVM")
+#   PRODUCT_LEGAL_COPYRIGHT
+#     Optional product legal copyright string
 #   )
 function(set_windows_version_resource_properties name resource_file)
   cmake_parse_arguments(ARG
     ""
-    "VERSION_MAJOR;VERSION_MINOR;VERSION_PATCHLEVEL;VERSION_STRING;PRODUCT_NAME"
+    "VERSION_MAJOR;VERSION_MINOR;VERSION_PATCHLEVEL;VERSION_STRING;PRODUCT_NAME;PRODUCT_LEGAL_COPYRIGHT"
     ""
     ${ARGN})
 
@@ -362,6 +364,10 @@ function(set_windows_version_resource_properties name resource_file)
     set(ARG_PRODUCT_NAME "LLVM")
   endif()
 
+  if (NOT DEFINED ARG_PRODUCT_LEGAL_COPYRIGHT)
+    set(ARG_PRODUCT_LEGAL_COPYRIGHT ${LEGAL_COPYRIGHT})
+  endif()
+
   set_property(SOURCE ${resource_file}
                PROPERTY COMPILE_FLAGS /nologo)
   set_property(SOURCE ${resource_file}
@@ -373,7 +379,8 @@ function(set_windows_version_resource_properties name resource_file)
                "RC_FILE_VERSION=\"${ARG_VERSION_STRING}\""
                "RC_INTERNAL_NAME=\"${name}\""
                "RC_PRODUCT_NAME=\"${ARG_PRODUCT_NAME}\""
-               "RC_PRODUCT_VERSION=\"${ARG_VERSION_STRING}\"")
+               "RC_PRODUCT_VERSION=\"${ARG_VERSION_STRING}\""
+               "RC_COPYRIGHT=\"${ARG_PRODUCT_LEGAL_COPYRIGHT}\"")
 endfunction(set_windows_version_resource_properties)
 
 # llvm_add_library(name sources...


### PR DESCRIPTION
It was not possible to set the copyright string for binaries. The RC_COPYRIGHT string in the windows resource definition would always be empty. Plumb this value through and set it explicitly in our CMAKE options.