### PR TITLE
Use stable VS build image

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -159,10 +159,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore1ESPool-Public
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre
+            demands: ImageOverride -equals Build.Windows.Amd64.VS2022
         steps:
         - checkout: self
           clean: true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -159,10 +159,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore1ESPool-Public
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Open
+            demands: windows.vs2022.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022
+            demands: windows.vs2022.amd64
         steps:
         - checkout: self
           clean: true

--- a/llvm.proj
+++ b/llvm.proj
@@ -15,7 +15,7 @@
 
     :: Try to locate installed VisualStudio VC environment.
     if "%VCINSTALLDIR%" == "" if exist "%VSWHERE_TOOLS_BIN%" (
-        for /f "tokens=*" %%a in ('"%VSWHERE_TOOLS_BIN%" -latest -property installationPath') do (
+        for /f "tokens=*" %%a in ('"%VSWHERE_TOOLS_BIN%" -latest -prerelease -property installationPath') do (
             set VS_VCINSTALL_DIR=%%a\VC\
         )
     )

--- a/llvm.proj
+++ b/llvm.proj
@@ -15,7 +15,7 @@
 
     :: Try to locate installed VisualStudio VC environment.
     if "%VCINSTALLDIR%" == "" if exist "%VSWHERE_TOOLS_BIN%" (
-        for /f "tokens=*" %%a in ('"%VSWHERE_TOOLS_BIN%" -latest -prerelease -property installationPath') do (
+        for /f "tokens=*" %%a in ('"%VSWHERE_TOOLS_BIN%" -latest -property installationPath') do (
             set VS_VCINSTALL_DIR=%%a\VC\
         )
     )


### PR DESCRIPTION
The preview image hits a build issue on Windows arm64 and the stable image now contains the MSVC ABI break that caused us to use the preview image before.

Also switch over to the new image names that dnceng wants us to use.