### PR TITLE
Add `FileCheck` and `llvm-mca` to the list of LLVM tools for LLVM.Tools package

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -66,7 +66,7 @@
     <_LLVMBuildArgs Include='-DLLVM_BUILD_TESTS=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_BUILD_EXAMPLES=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_INCLUDE_EXAMPLES=OFF' />
-    <_LLVMBuildArgs Include='-DLLVM_TOOLS_TO_BUILD="opt%3Bllc%3Bllvm-config%3Bllvm-dis%3Bllvm-mc%3Bllvm-as"' />
+    <_LLVMBuildArgs Include='-DLLVM_TOOLS_TO_BUILD="opt%3Bllc%3Bllvm-config%3Bllvm-dis%3Bllvm-mc%3Bllvm-as%3BFileCheck%3Bllvm-mca"' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_LIBXML2=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_TERMINFO=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_EXTERNALIZE_DEBUGINFO=ON' />

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -9,5 +9,7 @@
     <File Include="$(_LLVMInstallDir)\bin\opt.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\FileCheck.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -7,9 +7,9 @@
     <File Include="$(_LLVMInstallDir)\bin\llvm-as.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\FileCheck.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\llvm-mca" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\FileCheck.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\llvm-mca" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\llvm-mca.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -7,5 +7,7 @@
     <File Include="$(_LLVMInstallDir)\bin\llvm-as.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -7,5 +7,7 @@
     <File Include="$(_LLVMInstallDir)\bin\llvm-as.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -9,5 +9,7 @@
     <File Include="$(_LLVMInstallDir)\bin\opt.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\FileCheck.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -7,9 +7,9 @@
     <File Include="$(_LLVMInstallDir)\bin\llvm-as.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\FileCheck.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\llvm-mca" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\FileCheck.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\llvm-mca" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\llvm-mca.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -9,5 +9,7 @@
     <File Include="$(_LLVMInstallDir)\bin\opt.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\FileCheck.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\FileCheck.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -7,5 +7,7 @@
     <File Include="$(_LLVMInstallDir)\bin\llvm-as.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Tools.props
@@ -7,9 +7,9 @@
     <File Include="$(_LLVMInstallDir)\bin\llvm-as.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
     <File Include="$(_LLVMInstallDir)\bin\opt.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\FileCheck.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\FileCheck.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
-    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\FileCheck.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\FileCheck.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\llvm-mca.exe" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
+    <File Include="$(_LLVMBuildDir)\bin\llvm-mca.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**Description**

https://github.com/dotnet/runtime is wanting to start writing assembly (x64/ARM64) verification tests. Instead of building our own tool to support writing those kinds of tests, we want to leverage LLVM's `FileCheck`.

We also want to include `llvm-mca` at the request of @EgorBo 

'dotnet/runtime' already includes Mono and references the package 'Mono.LLVM.Tools' - it just doesn't include `FileCheck` or `llvm-mca` as part of the package. This PR should allow them to be included.

// cc @markples @JulieLeeMSFT @EgorBo