### PR TITLE
Add new NuGet package, `Microsoft.NETCore.Runtime.JIT.Tools`, includes `FileCheck` and `llvm-mca`

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -45,6 +45,7 @@
     <_LLVMBuildArgs Condition="'$(LLVMTableGenPath)' != ''" Include='-DLLVM_TABLEGEN="$(LLVMTableGenPath)"' />
     <_LLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=$(Configuration)" />
     <_LLVMBuildArgs Include='-DLLVM_BUILD_TOOLS:BOOL=ON' />
+    <_LLVMBuildArgs Include='-DLLVM_INSTALL_UTILS:BOOL=ON' />
     <_LLVMBuildArgs Include='-DLEGAL_COPYRIGHT:STRING="\xa9 Microsoft Corporation. All rights reserved."' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_TERMINFO:BOOL=OFF' />
     <_LLVMBuildArgs Include="-DLLVM_INCLUDE_UTILS:BOOL=ON" />

--- a/llvm.proj
+++ b/llvm.proj
@@ -28,10 +28,14 @@
     </_SetupEnvironment>
     <_CMakeConfigureCommand>$(_SetupEnvironment) cmake $(_LLVMSourceDir) -G "$(CMakeGenerator)" @(_LLVMBuildArgs->'%(Identity)',' ')</_CMakeConfigureCommand>
     <_BuildSubset Condition="'$(BuildLLVMTableGenOnly)' == 'true'">llvm-tblgen</_BuildSubset>
-    <_BuildSubset Condition="'$(BuildLLVMTableGenOnly)' != 'true'">objwriter</_BuildSubset>
+    <_BuildSubset Condition="'$(BuildLLVMTableGenOnly)' != 'true'">objwriter llvm-mca FileCheck</_BuildSubset>
     <_BuildCommand Condition="'$(CMakeGenerator)' == 'Unix Makefiles'">$(_SetupEnvironment) make $(_BuildSubset) -j$([System.Environment]::ProcessorCount)</_BuildCommand>
     <_BuildCommand Condition="'$(CMakeGenerator)' == 'Ninja'">$(_SetupEnvironment) ninja $(_BuildSubset)</_BuildCommand>
-    <_CMakeInstallCommand>$(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=objwriter -P cmake_install.cmake</_CMakeInstallCommand>
+    <_CMakeInstallCommand>
+        $(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=objwriter -P cmake_install.cmake
+        $(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=llvm-mca -P cmake_install.cmake
+        $(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=FileCheck -P cmake_install.cmake
+    </_CMakeInstallCommand>
   </PropertyGroup>
 
 <!---DLLVM_TABLEGEN=C:\Users\Alexander\Desktop\llvm-project\build-x64\bin\llvm-tblgen.exe-->
@@ -40,10 +44,10 @@
     <_LLVMBuildArgs Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildOS)' == 'OSX'" Include="-DCMAKE_OSX_ARCHITECTURES=arm64"/>
     <_LLVMBuildArgs Condition="'$(LLVMTableGenPath)' != ''" Include='-DLLVM_TABLEGEN="$(LLVMTableGenPath)"' />
     <_LLVMBuildArgs Include="-DCMAKE_BUILD_TYPE=$(Configuration)" />
-    <_LLVMBuildArgs Include='-DLLVM_BUILD_TOOLS:BOOL=OFF' />
+    <_LLVMBuildArgs Include='-DLLVM_BUILD_TOOLS:BOOL=ON' />
     <_LLVMBuildArgs Include='-DLEGAL_COPYRIGHT:STRING="\xa9 Microsoft Corporation. All rights reserved."' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_TERMINFO:BOOL=OFF' />
-    <_LLVMBuildArgs Include="-DLLVM_INCLUDE_UTILS:BOOL=OFF" />
+    <_LLVMBuildArgs Include="-DLLVM_INCLUDE_UTILS:BOOL=ON" />
     <_LLVMBuildArgs Include="-DLLVM_INCLUDE_RUNTIMES:BOOL=OFF" />
     <_LLVMBuildArgs Include="-DLLVM_INCLUDE_EXAMPLES:BOOL=OFF" />
     <_LLVMBuildArgs Include="-DLLVM_INCLUDE_TESTS:BOOL=OFF" />

--- a/llvm.proj
+++ b/llvm.proj
@@ -32,9 +32,11 @@
     <_BuildCommand Condition="'$(CMakeGenerator)' == 'Unix Makefiles'">$(_SetupEnvironment) make $(_BuildSubset) -j$([System.Environment]::ProcessorCount)</_BuildCommand>
     <_BuildCommand Condition="'$(CMakeGenerator)' == 'Ninja'">$(_SetupEnvironment) ninja $(_BuildSubset)</_BuildCommand>
     <_CMakeInstallCommand>
-        $(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=objwriter -P cmake_install.cmake
-        $(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=llvm-mca -P cmake_install.cmake
-        $(_SetupEnvironment) cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=FileCheck -P cmake_install.cmake
+    $(_SetupEnvironment) 
+
+    cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=objwriter -P cmake_install.cmake
+    cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=llvm-mca -P cmake_install.cmake
+    cmake -DCMAKE_INSTALL_DO_STRIP=1 -DCMAKE_INSTALL_PREFIX=$(_LLVMInstallDir) -DCMAKE_INSTALL_COMPONENT=FileCheck -P cmake_install.cmake
     </_CMakeInstallCommand>
   </PropertyGroup>
 

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/Directory.Build.props
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/Directory.Build.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../Directory.Build.props" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/Microsoft.NETCore.Runtime.JIT.Tools.builds
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/Microsoft.NETCore.Runtime.JIT.Tools.builds
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.Build.Traversal">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(builds.targets))" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/Microsoft.NETCore.Runtime.JIT.Tools.pkgproj
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/Microsoft.NETCore.Runtime.JIT.Tools.pkgproj
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <Import Condition="'$(_packageTargetOSGroup)' != ''"  Project="$(MSBuildThisFileDirectory)runtime.$(_packageTargetOSGroup).$(MSBuildProjectName).props" />
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.Linux.Microsoft.NETCore.Runtime.JIT.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.Linux.Microsoft.NETCore.Runtime.JIT.Tools.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <File Include="$(_LLVMInstallDir)\lib\libobjwriter.so" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+  </ItemGroup>
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.Linux.Microsoft.NETCore.Runtime.JIT.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.Linux.Microsoft.NETCore.Runtime.JIT.Tools.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="$(_LLVMInstallDir)\lib\libobjwriter.so" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.OSX.Microsoft.NETCore.Runtime.JIT.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.OSX.Microsoft.NETCore.Runtime.JIT.Tools.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <File Include="$(_LLVMInstallDir)\lib\libobjwriter.dylib" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+  </ItemGroup>
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.OSX.Microsoft.NETCore.Runtime.JIT.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.OSX.Microsoft.NETCore.Runtime.JIT.Tools.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="$(_LLVMInstallDir)\lib\libobjwriter.dylib" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.JIT.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.JIT.Tools.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <File Include="$(_LLVMInstallDir)\bin\objwriter.dll" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+  </ItemGroup>
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.JIT.Tools.props
+++ b/nuget/Microsoft.NETCore.Runtime.JIT.Tools/runtime.Windows_NT.Microsoft.NETCore.Runtime.JIT.Tools.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <File Include="$(_LLVMInstallDir)\bin\objwriter.dll" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.exe" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck.exe" TargetPath="runtimes\$(PackageTargetRuntime)\native\" />
   </ItemGroup>
 </Project>

--- a/nuget/descriptions.json
+++ b/nuget/descriptions.json
@@ -13,5 +13,10 @@
         "Name": "Microsoft.NETCore.Runtime.ObjWriter",
         "Description": "ELF/PE/Mach-O object file writer based on LLVM used in .NET AOT compiler. Internal implementation package not meant for direct consumption.  Please do not reference directly.",
         "CommonTypes": [ ]
+    },
+    {
+        "Name": "Microsoft.NETCore.Runtime.JIT.Tools",
+        "Description": "Tools such as FileCheck and llvm-mca used for testing the .NET JIT compiler. Internal implementation package not meant for direct consumption.  Please do not reference directly.",
+        "CommonTypes": [ ]
     }
 ]

--- a/nuget/packages.builds
+++ b/nuget/packages.builds
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
     <ProjectReference Include="Microsoft.NETCore.Runtime.ObjWriter\Microsoft.NETCore.Runtime.ObjWriter.builds" />
+    <ProjectReference Include="Microsoft.NETCore.Runtime.JIT.Tools\Microsoft.NETCore.Runtime.JIT.Tools.builds" />
   </ItemGroup>
 
   <!-- Generate a version.txt file we include in our packages


### PR DESCRIPTION
**Description**

https://github.com/dotnet/runtime is wanting to start writing assembly (x64/ARM64) verification tests. Instead of building our own tool to support writing those kinds of tests, we want to leverage LLVM's `FileCheck`.

We also want to include `llvm-mca` at the request of @EgorBo 

This PR creates a new NuGet package for `dotnet/runtime` to consume which we named `Microsoft.NETCore.Runtime.JIT.Tools`. So far, this package only includes LLVM's `FileCheck` and `llvm-mca` tools.

// cc @markples @JulieLeeMSFT @EgorBo @akoeplinger 