### PR TITLE
Get rid of osx.10.12-x64 and osx.11.0-arm64. It isn't helpful.

### DIFF
--- a/nuget/Directory.Build.props
+++ b/nuget/Directory.Build.props
@@ -12,7 +12,7 @@
 
     <!-- Distro rid is passed as runtimeos-arch-->
     <_parseDistroRid>$(__DistroRid)</_parseDistroRid>
-    <_parseDistroRid Condition="'$(_parseDistroRid)' == '' && '$(__BuildOS)' == 'OSX'">osx-$(Platform)</_parseDistroRid>
+    <_parseDistroRid Condition="'$(_parseDistroRid)' == '' and '$(__BuildOS)' == 'OSX'">osx-$(Platform)</_parseDistroRid>
     <_distroRidIndex>$(_parseDistroRid.IndexOfAny("-"))</_distroRidIndex>
     <_archRidIndex>$([MSBuild]::Add($(_distroRidIndex), 1))</_archRidIndex>
     <OSRid Condition="'$(OSRid)' == '' and '$(_distroRidIndex)' != '-1'">$(_parseDistroRid.SubString(0, $(_distroRidIndex)))</OSRid>

--- a/nuget/Directory.Build.props
+++ b/nuget/Directory.Build.props
@@ -12,6 +12,7 @@
 
     <!-- Distro rid is passed as runtimeos-arch-->
     <_parseDistroRid>$(__DistroRid)</_parseDistroRid>
+    <_parseDistroRid Condition="'$(_parseDistroRid)' == '' && '$(__BuildOS)' == 'OSX'">osx-$(Platform)</_parseDistroRid>
     <_distroRidIndex>$(_parseDistroRid.IndexOfAny("-"))</_distroRidIndex>
     <_archRidIndex>$([MSBuild]::Add($(_distroRidIndex), 1))</_archRidIndex>
     <OSRid Condition="'$(OSRid)' == '' and '$(_distroRidIndex)' != '-1'">$(_parseDistroRid.SubString(0, $(_distroRidIndex)))</OSRid>

--- a/nuget/Directory.Build.props
+++ b/nuget/Directory.Build.props
@@ -12,8 +12,6 @@
 
     <!-- Distro rid is passed as runtimeos-arch-->
     <_parseDistroRid>$(__DistroRid)</_parseDistroRid>
-    <_parseDistroRid Condition="'$(_parseDistroRid)' == '' and '$(__BuildOS)' == 'OSX' and '$(Platform)' == 'arm64'">osx.11.0-arm64</_parseDistroRid>
-    <_parseDistroRid Condition="'$(_parseDistroRid)' == '' and '$(__BuildOS)' == 'OSX' and '$(Platform)' != 'arm64'">osx.10.12-x64</_parseDistroRid>
     <_distroRidIndex>$(_parseDistroRid.IndexOfAny("-"))</_distroRidIndex>
     <_archRidIndex>$([MSBuild]::Add($(_distroRidIndex), 1))</_archRidIndex>
     <OSRid Condition="'$(OSRid)' == '' and '$(_distroRidIndex)' != '-1'">$(_parseDistroRid.SubString(0, $(_distroRidIndex)))</OSRid>
@@ -79,8 +77,7 @@
     </When>
     <When Condition="'$(_runtimeOSFamily)' == 'osx'">
       <PropertyGroup>
-        <PackageRID Condition="'$(ArchGroup)' != 'arm64'">osx.10.12-$(ArchGroup)</PackageRID>
-        <PackageRID Condition="'$(ArchGroup)' == 'arm64'">osx.11.0-$(ArchGroup)</PackageRID>
+        <PackageRID>osx-$(ArchGroup)</PackageRID>
         <!-- Set the platform part of the RID if we are doing a portable build -->
         <PackageRID Condition="'$(PortableBuild)' == 'true'">osx-$(ArchGroup)</PackageRID>
       </PropertyGroup>


### PR DESCRIPTION
Turns out, being simple is much better than being correct. Versioning the osx version might be correct, but it achieves literally nothing except more complex msbuild files downstream.