### PR TITLE
Enable CI in objwriter/release/7.0

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -2,12 +2,12 @@ trigger:
   batch: true
   branches:
     include:
-    - objwriter/12.x
+    - objwriter/*
 
 pr:
   branches:
     include:
-    - objwriter/12.x
+    - objwriter/*
 
 variables:
 - template: /eng/common-variables.yml
@@ -198,7 +198,7 @@ stages:
               LLVMTableGenArg: /p:LLVMTableGenPath=$(Build.SourcesDirectory)\artifacts\obj\BuildRoot-x64\bin\llvm-tblgen.exe
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore1ESPool-Public
+            name: NetCore-Public
             demands: windows.vs2022.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -158,7 +158,7 @@ stages:
               archflag: --arch arm64
               LLVMTableGenArg: /p:LLVMTableGenPath=$(Build.SourcesDirectory)/artifacts/obj/BuildRoot-x64/bin/llvm-tblgen
         pool:
-          vmImage: macOS-10.15
+          vmImage: macos-11
         steps:
         - bash: |
             set -ex


### PR DESCRIPTION
This should enable the CI. Also updating public pool names that happened after we forked. Not updating public pool names under eng/common - that should happen in an Arcade update and we have no problem waiting for that.

Cc @sbomer @markples 