### PR TITLE
Add API for emitting compact unwind encoding

### DIFF
--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -1003,6 +1003,7 @@ public:
   virtual void emitCFIRegister(int64_t Register1, int64_t Register2);
   virtual void emitCFIWindowSave();
   virtual void emitCFINegateRAState();
+  virtual void emitCFICompactUnwindEncoding(unsigned Encoding);
 
   virtual void EmitWinCFIStartProc(const MCSymbol *Symbol, SMLoc Loc = SMLoc());
   virtual void EmitWinCFIEndProc(SMLoc Loc = SMLoc());

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -122,9 +122,12 @@ void MCStreamer::addExplicitComment(const Twine &T) {}
 void MCStreamer::emitExplicitComments() {}
 
 void MCStreamer::generateCompactUnwindEncodings(MCAsmBackend *MAB) {
-  for (auto &FI : DwarfFrameInfos)
-    FI.CompactUnwindEncoding =
-        (MAB ? MAB->generateCompactUnwindEncoding(FI.Instructions) : 0);
+  for (auto &FI : DwarfFrameInfos) {
+    if (FI.CompactUnwindEncoding == 0) {
+      FI.CompactUnwindEncoding =
+          (MAB ? MAB->generateCompactUnwindEncoding(FI.Instructions) : 0);
+    }
+  }
 }
 
 /// EmitIntValue - Special case of EmitValue that avoids the client having to
@@ -658,6 +661,14 @@ void MCStreamer::emitCFINegateRAState() {
   if (!CurFrame)
     return;
   CurFrame->Instructions.push_back(Instruction);
+}
+
+void MCStreamer::emitCFICompactUnwindEncoding(unsigned Encoding)
+{
+  MCDwarfFrameInfo *CurFrame = getCurrentDwarfFrameInfo();
+  if (!CurFrame)
+    return;
+  CurFrame->CompactUnwindEncoding = Encoding;
 }
 
 void MCStreamer::emitCFIReturnColumn(int64_t Register) {

--- a/llvm/tools/objwriter/objwriter.cpp
+++ b/llvm/tools/objwriter/objwriter.cpp
@@ -648,6 +648,23 @@ void ObjectWriter::EmitCFICode(int Offset, const char *Blob) {
 
 void ObjectWriter::EmitCFICompactUnwindEncoding(unsigned int Encoding)
 {
+  // Emits architecture specific compact unwinding encoding for MachO
+  // files on Apple platforms. Currently that's the only platform where
+  // compact unwinding tables are used.
+  //
+  // If EmitCFICompactUnwindEncoding is never called then EmitCFIEnd
+  // will cause compact unwinding to reference DWARF CFI info. It
+  // essentially turns the compact unwinding tables into an index for
+  // the DWARF CFI data, much like .eh_frame_hdr works in ELF files.
+  //
+  // If Encoding is set to zero it instructs LLVM to infer the compact
+  // unwinding encoding from the DWARF CFI data.
+  //
+  // Any non-zero value in Encoding is emitted directly into the
+  // __compact_unwind section and then processed by the linker.
+  //
+  // See generateCompactUnwindEncoding in AArch64AsmBackend.cpp and
+  // X86AsmBackend.cpp for specific encodings for a given architecture.
   FrameHasCompactEncoding = true;
   Streamer->emitCFICompactUnwindEncoding(Encoding);
 }

--- a/llvm/tools/objwriter/objwriter.exports
+++ b/llvm/tools/objwriter/objwriter.exports
@@ -13,6 +13,7 @@ EmitCFIStart
 EmitCFIEnd
 EmitCFILsda
 EmitCFICode
+EmitCFICompactUnwindEncoding
 EmitDebugFileInfo
 EmitDebugFunctionInfo
 EmitDebugVar

--- a/llvm/tools/objwriter/objwriter.h
+++ b/llvm/tools/objwriter/objwriter.h
@@ -100,6 +100,7 @@ public:
   void EmitCFIEnd(int Offset);
   void EmitCFILsda(const char *LsdaBlobSymbolName);
   void EmitCFICode(int Offset, const char *Blob);
+  void EmitCFICompactUnwindEncoding(unsigned int Encoding);
 
   unsigned GetEnumTypeIndex(const EnumTypeDescriptor &TypeDescriptor,
                             const EnumRecordTypeDescriptor *TypeRecords);
@@ -180,6 +181,7 @@ private:
   std::unique_ptr<raw_fd_ostream> OS;
   MCTargetOptions TargetMOptions;
   bool FrameOpened;
+  bool FrameHasCompactEncoding;
   std::vector<DebugVarInfo> DebugVarInfos;
   std::vector<DebugEHClauseInfo> DebugEHClauseInfos;
   DenseSet<MCSymbol *> AddressTakenFunctions;
@@ -284,6 +286,11 @@ DLL_EXPORT STDMETHODCALLTYPE void EmitCFILsda(ObjectWriter *OW, const char *Lsda
 DLL_EXPORT STDMETHODCALLTYPE void EmitCFICode(ObjectWriter *OW, int Offset, const char *Blob) {
   assert(OW && "ObjWriter is null");
   OW->EmitCFICode(Offset, Blob);
+}
+
+DLL_EXPORT STDMETHODCALLTYPE void EmitCFICompactUnwindEncoding(ObjectWriter *OW, unsigned int Encoding) {
+  assert(OW && "ObjWriter is null");
+  OW->EmitCFICompactUnwindEncoding(Encoding);
 }
 
 DLL_EXPORT STDMETHODCALLTYPE void EmitDebugFileInfo(ObjectWriter *OW, int FileId,


### PR DESCRIPTION
…enforce DWARF encoding if not explicitly overridden

Currently `objwriter` will do best effort to convert DWARF CFI codes into compact unwinding encoding. On osx-arm64 we always fail this due to the way NativeAOT code generator emits prologs. It falls back into the "use DWARF CFI encoding" which the linker turns into efficient index. On osx-x64 we never hit the code since ILCompiler doesn't specify macOS/Darwin version in the triple and thus compact unwinding is not generated by objwriter. The conversion is then done by the ld64 linker where we have only limited control over what is produced.

With the change we get new options:
- By default `objwriter` will always use the "use DWARF CFI encoding" value in the compact unwinding tables. That ensures we have DWARF CFI info available and that we can unwind function prologs and epilogs.
- New `EmitCFICompactUnwindEncoding` API is introduced which can force specific encoding.
  - If the parameter is set to `0` it will switch to the previous behavior and let LLVM try to convert DWARF CFI into compact unwinding.
  - If the parameter is set to anything but zero it's assumed to be the architecture specific compact unwinding encoding. The code generator can produce it more efficiently and reliably than the conversion from DWARF CFI.

I don't currently intend to use the `EmitCFICompactUnwindEncoding` API on NativeAOT side but it may change in future if we decide to produce compatible prologs/epilogs and use compact unwinding. On osx-x64 the compact unwinding is still not generated by default unless `darwin10` (or newer) is used in the triple. I intend NativeAOT to do that.