### PR TITLE
Add support for generating uninitialized sections

### DIFF
--- a/llvm/tools/objwriter/objwriter.h
+++ b/llvm/tools/objwriter/objwriter.h
@@ -44,6 +44,7 @@ enum CustomSectionAttributes : int32_t {
   CustomSectionAttributes_ReadOnly = 0x0000,
   CustomSectionAttributes_Writeable = 0x0001,
   CustomSectionAttributes_Executable = 0x0002,
+  CustomSectionAttributes_Uninitialized = 0x0004,
   CustomSectionAttributes_MachO_Init_Func_Pointers = 0x0100,
 };
 


### PR DESCRIPTION
We support `.bss` but not custom sections that are bss-like. This adds such support.

Cc @markples @BrianBohe 