### PR TITLE
Do not indiscriminately create text section

### DIFF
--- a/llvm/tools/objwriter/objwriter.cpp
+++ b/llvm/tools/objwriter/objwriter.cpp
@@ -140,8 +140,6 @@ bool ObjectWriter::Init(llvm::StringRef ObjectFilePath, const char* tripleName) 
   FrameOpened = false;
   FuncId = 1;
 
-  SetCodeSectionAttribute("text", CustomSectionAttributes_Executable, nullptr);
-
   if (ObjFileInfo->getObjectFileType() == ObjFileInfo->IsCOFF) {
     TypeBuilder.reset(new UserDefinedCodeViewTypesBuilder());
   } else {


### PR DESCRIPTION
If we ended up with nothing in the text section, this line would error LLVM out in:

https://github.com/dotnet/llvm-project/blob/3db8d68195c17386557f1a258312bbae4051dc05/llvm/lib/MC/ELFObjectWriter.cpp#L1458-L1459

...because we generate a reference to the empty text section in the `aranges` section where `SetCodeSectionAttribute` registered it.

I double checked and debugging on Linux still works fine without this. `SetCodeSectionAttribute` is an objwriter API and we have access to it from the managed side. We should be calling it from there if it's needed for something that I didn't realize (we do call it from the managed side for the `.managed` section, but that one actually has debug information generated, unlike `.text`).

Cc @BrianBohe @markples 