### PR TITLE
Enable codeql with TSA in separate pipeline

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\mono",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
+    "repositoryName": "llvm-project",
+    "codebaseName": "llvm-project"
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-# **DO NOT FILE A PULL REQUEST**
-
-This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.
-
-# **DO NOT FILE A PULL REQUEST**

--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -67,7 +67,7 @@ stages:
       ############ MACOS BUILD ############
       - job: Build_macOS
         displayName: macOS
-        timeoutInMinutes: 480
+        timeoutInMinutes: 720
         variables:
         - _BuildConfig: Release
         strategy:
@@ -96,7 +96,7 @@ stages:
       ############ WINDOWS BUILD ############
       - job: Build_Windows
         displayName: Windows
-        timeoutInMinutes: 480
+        timeoutInMinutes: 720
         strategy:
           matrix:
             # Release

--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -1,0 +1,130 @@
+trigger:
+  none
+
+schedules:
+  - cron: 0 12 * * 1
+    displayName: Weekly Monday CodeQL/Semmle run
+    branches:
+      include:
+      - main
+    always: true
+
+variables:
+  - template: /eng/common-variables.yml
+  - name: Codeql.Enabled
+    value: True
+  - name: Codeql.Cadence
+    value: 0
+  - name: Codeql.TSAEnabled
+    value: True
+  - name: Codeql.BuildIdentifier
+    value: $(System.JobDisplayName)
+
+stages:
+- stage: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      jobs:
+
+      ############ LINUX BUILD ############
+      - job: Build_Linux
+        displayName: Linux
+        timeoutInMinutes: 480
+        variables:
+        - _BuildConfig: Release
+        strategy:
+          matrix:
+            x64:
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20220716123527-d0bc8ed
+              archflag: --arch x64
+              Devtoolset7Arg: /p:ForceDevtoolset7=true
+        pool:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            vmImage: ubuntu-20.04
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+        container:
+          image: $(imagename)
+        steps:
+        - bash: |
+            set -ex
+            git clean -ffdx
+            git reset --hard HEAD
+          displayName: 'Clean up working directory'
+
+        - task: CodeQL3000Init@0
+          displayName: Initialize CodeQL (manually-injected)
+
+        - bash: |
+            ./build.sh --ci --restore --build $(archflag) --configuration $(_BuildConfig) $(_InternalBuildArgs) $(Devtoolset7Arg)
+          displayName: 'Build'
+
+        - task: CodeQL3000Finalize@0
+          displayName: Finalize CodeQL (manually-injected)
+
+      ############ MACOS BUILD ############
+      - job: Build_macOS
+        displayName: macOS
+        timeoutInMinutes: 480
+        variables:
+        - _BuildConfig: Release
+        strategy:
+          matrix:
+            x64:
+              archflag: --arch x64
+        pool:
+          vmImage: macos-11
+        steps:
+        - bash: |
+            set -ex
+            git clean -ffdx
+            git reset --hard HEAD
+          displayName: 'Clean up working directory'
+
+        - task: CodeQL3000Init@0
+          displayName: Initialize CodeQL (manually-injected)
+
+        - bash: |
+            ./build.sh --ci --restore --build $(archflag) --configuration $(_BuildConfig) $(_InternalBuildArgs)
+          displayName: 'Build'
+
+        - task: CodeQL3000Finalize@0
+          displayName: Finalize CodeQL (manually-injected)
+
+      ############ WINDOWS BUILD ############
+      - job: Build_Windows
+        displayName: Windows
+        timeoutInMinutes: 480
+        strategy:
+          matrix:
+            # Release
+            x64_release:
+              _BuildConfig: Release
+              archflag: -arch x64
+        pool:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            name: NetCore-Public
+            demands: windows.vs2022.amd64.open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            name: NetCore1ESPool-Internal
+            demands: windows.vs2022.amd64
+        steps:
+        - checkout: self
+          clean: true
+          fetchDepth: 2
+
+        - script: |
+            git clean -ffdx
+            git reset --hard HEAD
+          displayName: 'Clean up working directory'
+
+        - task: CodeQL3000Init@0
+          displayName: Initialize CodeQL (manually-injected)
+
+        - powershell: eng\build.ps1 -ci -restore -build $(archflag) -configuration $(_BuildConfig) $(_InternalBuildArgs)
+          displayName: 'Build'
+
+        - task: CodeQL3000Finalize@0
+          displayName: Finalize CodeQL (manually-injected)

--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -6,7 +6,8 @@ schedules:
     displayName: Weekly Monday CodeQL/Semmle run
     branches:
       include:
-      - main
+      - dotnet/main
+      - objwriter/12.x
     always: true
 
 variables:

--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -64,39 +64,10 @@ stages:
         - task: CodeQL3000Finalize@0
           displayName: Finalize CodeQL (manually-injected)
 
-      ############ MACOS BUILD ############
-      - job: Build_macOS
-        displayName: macOS
-        timeoutInMinutes: 720
-        variables:
-        - _BuildConfig: Release
-        strategy:
-          matrix:
-            x64:
-              archflag: --arch x64
-        pool:
-          vmImage: macos-11
-        steps:
-        - bash: |
-            set -ex
-            git clean -ffdx
-            git reset --hard HEAD
-          displayName: 'Clean up working directory'
-
-        - task: CodeQL3000Init@0
-          displayName: Initialize CodeQL (manually-injected)
-
-        - bash: |
-            ./build.sh --ci --restore --build $(archflag) --configuration $(_BuildConfig) $(_InternalBuildArgs)
-          displayName: 'Build'
-
-        - task: CodeQL3000Finalize@0
-          displayName: Finalize CodeQL (manually-injected)
-
       ############ WINDOWS BUILD ############
       - job: Build_Windows
         displayName: Windows
-        timeoutInMinutes: 720
+        timeoutInMinutes: 600
         strategy:
           matrix:
             # Release


### PR DESCRIPTION
CodeQL is a static analysis tool that is able to scan source code to help detect security vulnerabilities. In dotnet/llvm-project there already exists auto-injection of CodeQL's init and finalize tasks within official pipelines.

Although we can enable CodeQL within the official pipeline, the impact on main would significantly slow down builds. Instead, we aim to enable CodeQL on a subset of jobs that would lead to a high amount of code coverage; as such, having a separate pipeline that targets these minimal subset of jobs makes more sense (compared to opting in/out for each specific job within the pipeline).

This PR does the following:
Manually inject CodeQL Init and Finalize tasks to wrap around a stripped down version of the builds.
Enables CodeQL in a separate pipeline with a weekly schedule based on the main branch
Enable TSA with CodeQL
Scans Linux and Windows x64 Builds
Removes the Pull Request template as that applies to the llvm/llvm-project repo, not this fork