### PR TITLE
Dynamically link ucrt to objwriter.dll

### DIFF
--- a/llvm/tools/objwriter/CMakeLists.txt
+++ b/llvm/tools/objwriter/CMakeLists.txt
@@ -7,6 +7,11 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
+if (MSVC)
+  # Force uCRT to be dynamically linked for Release build
+  set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+endif()
+
 message(STATUS "ObjWriter configuring with (${CMAKE_BUILD_TYPE}) build type and (${LLVM_DEFAULT_TARGET_TRIPLE}) default target triple")
 
 add_llvm_library(objwriter SHARED


### PR DESCRIPTION
Makes objwriter.dll about 200 kB smaller.

This is how we link CRT in the runtime repo:

https://github.com/dotnet/runtime/blob/b2cf1c7a3796d5fb5acb0237017d8a61c6d3dc6b/eng/native/configurecompiler.cmake#L104-L106

Cc @BrianBohe @markples @dotnet/ilc-contrib 