### PR TITLE
Fix off-by-one error in DWARF reg-reg location

### DIFF
--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfGen.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfGen.cpp
@@ -419,7 +419,7 @@ static void EmitVarLocation(MCObjectStreamer *Streamer,
       if (IsLocList) {
         Streamer->emitIntValue(Len, 2);
       } else {
-        Streamer->emitULEB128IntValue(Len + 1);
+        Streamer->emitULEB128IntValue(Len);
       }
 
       EmitReg(Streamer, DwarfRegNum2);


### PR DESCRIPTION
The DWARF specification states that the form of an exprloc consists of an unsigned LEB128 length value, followed by the encoded location bytes of the specified length. For some reason we were adding one to the length value being emitted. This looks incorrect to me. The above calculation for REG-REG (a variable stored in two registers) correctly calculates the length of each register type tag, plus the size of the interpolating PIECE tags, plus the size of notation for each register. The extra byte looks wrong.

I've tested this locally and it appears to resolve https://github.com/dotnet/runtime/issues/77407.

Unfortunately, it also causes llvm-dwarfdump --verify to constantly complain about missing base addresses. I can't confirm at the moment, but my suspicion is that this is revealing an existing bug. Even if this is somehow causing a new bug, I think the resulting symbols with this change are better than the alternative (no working symbols at all).