### PR TITLE
Fix off-by-one error in DWARF reg-reg location (#317)

### DIFF
--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfGen.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfGen.cpp
@@ -419,7 +419,7 @@ static void EmitVarLocation(MCObjectStreamer *Streamer,
       if (IsLocList) {
         Streamer->emitIntValue(Len, 2);
       } else {
-        Streamer->emitULEB128IntValue(Len + 1);
+        Streamer->emitULEB128IntValue(Len);
       }
 
       EmitReg(Streamer, DwarfRegNum2);


### PR DESCRIPTION
Backport of #317 

# Customer impact

Without this change, symbols are broken on Linux release builds such that no debugging is functional. Found in both manual testing and customer reported soon after shipping.

# Testing

Manual testing. Verified using llvm-dwarfdump and gdb, and verified no Windows regression using Visual Studio.

# Risk

Low. This is a focused change, and Windows has been scouted for regressions. It's probably not possible to make Linux worse than it already is.