### PR TITLE
Do not try to build LLVM with Zlib on Windows

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -78,6 +78,7 @@
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT' and '$(Configuration)' == 'Release'" Include='-DLLVM_USE_CRT_RELEASE=MT' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT' and '$(Configuration)' == 'Debug'" Include='-DLLVM_USE_CRT_DEBUG=MTd' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT' and '$(Configuration)' == 'Debug'" Include='-DLLVM_USE_CRT_RELEASE=MTd' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_ENABLE_ZLIB=OFF' />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CMake is accidentally picking up zlib from the CI environment, see https://github.com/actions/runner-images/issues/6627#issuecomment-1328214957, the build log now has this line:
```
  -- Found ZLIB: C:/Strawberry/c/lib/libz.a (found version "1.2.11") 
```

Disable zlib on Windows since we don't want the dependency there, this is also what Rust did a while back: https://github.com/rust-lang/rust/pull/85762