### PR TITLE
[objwriter/release/7.0] Do not use zlib on Windows

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -52,6 +52,7 @@
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_PDB:BOOL=ON' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_USE_CRT_DEBUG=MTd' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_USE_CRT_RELEASE=MT' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_ENABLE_ZLIB=OFF' />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildOS)' != 'Windows_NT'">


### PR DESCRIPTION
Cc @agocke - this is a build change to restore status quo. The next build from release/7.0 (once we ingest an Arcade update I guess) is likely going to be bad. We can wait with merging this on that.

Do we need tactics approval for this?