### PR TITLE
Fix demands in azure-pipelines.yml

### DIFF
--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -78,10 +78,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Public
-            demands: windows.vs2022.amd64.open
+            demands: ImageOverride -equals windows.vs2022.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
-            demands: windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
         steps:
         - checkout: self
           clean: true

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -187,10 +187,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Public
-            demands: windows.vs2022.amd64.open
+            demands: ImageOverride -equals windows.vs2022.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
-            demands: windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
We actually built on the wrong image since the `demands` was wrong and it just fell back to a default AzDO image.