### PR TITLE
[objwriter/12.x] Fix demands in azure-pipelines.yml

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -199,10 +199,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Public
-            demands: windows.vs2022.amd64.open
+            demands: ImageOverride -equals windows.vs2022.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
-            demands: windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
         steps:
         - script: |
             git clean -ffdx


### PR DESCRIPTION
Ports https://github.com/dotnet/llvm-project/pull/335 to the objwriter branch.

Note that this still uses VS2022 so that we get the new VS in the "main" branch, we'll use VS2019 for the objwriter servicing branch.