### PR TITLE
[objwriter/release/7.0] Fix demands in azure-pipelines.yml

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -199,10 +199,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Svc-Public
-            demands: windows.vs2022.amd64.open
+            demands: ImageOverride -equals windows.vs2019.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Svc-Internal
-            demands: windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2019.amd64
         steps:
         - script: |
             git clean -ffdx


### PR DESCRIPTION
Ports https://github.com/dotnet/llvm-project/pull/335 to the objwriter 7.0 servicing branch.

This uses the VS2019 image which is what AzDO defaulted to before.