### PR TITLE
Only create ObjWriter and JIT.Tools package in Release

### DIFF
--- a/nuget/packages.builds
+++ b/nuget/packages.builds
@@ -2,10 +2,10 @@
   <ItemGroup>
     <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Sdk\Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.builds" />
     <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Tools\Microsoft.NETCore.Runtime.Mono.LLVM.Tools.builds" />
+    <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.ObjWriter\Microsoft.NETCore.Runtime.ObjWriter.builds" />
+    <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.JIT.Tools\Microsoft.NETCore.Runtime.JIT.Tools.builds" />
     <ProjectReference Condition="'$(Configuration)' == 'Debug'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Sdk\Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.Debug.builds" />
     <ProjectReference Condition="'$(Configuration)' == 'Debug'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Tools\Microsoft.NETCore.Runtime.Mono.LLVM.Tools.Debug.builds" />
-    <ProjectReference Include="Microsoft.NETCore.Runtime.ObjWriter\Microsoft.NETCore.Runtime.ObjWriter.builds" />
-    <ProjectReference Include="Microsoft.NETCore.Runtime.JIT.Tools\Microsoft.NETCore.Runtime.JIT.Tools.builds" />
   </ItemGroup>
 
   <!-- Generate a version.txt file we include in our packages


### PR DESCRIPTION
Creating in both queues is causing a collision during package upload as the packages have the same name and version.