### PR TITLE
Fix no-children warnings in objwriter output

### DIFF
--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfTypeBuilder.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfTypeBuilder.cpp
@@ -417,7 +417,7 @@ void DwarfClassTypeInfo::Dump(UserDefinedDwarfTypesBuilder *TypeBuilder, MCObjec
   }
 
   if (isEmpty) {
-      // If there are no child nodes we need to write an empty record
+    // If there are no child nodes we need to write an empty record
     Streamer->emitIntValue(0, 1);
   }
 

--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfTypeBuilder.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfTypeBuilder.cpp
@@ -399,16 +399,26 @@ void DwarfClassTypeInfo::Dump(UserDefinedDwarfTypesBuilder *TypeBuilder, MCObjec
   if (IsForwardDecl)
     return;
 
+  bool isEmpty = true;
+
   for (auto &Field : Fields) {
+    isEmpty = false;
     Field.Dump(TypeBuilder, Streamer, TypeSection, StrSection);
   }
 
   for (auto &StaticField : StaticFields) {
+    isEmpty = false;
     StaticField.Dump(TypeBuilder, Streamer, TypeSection, StrSection);
   }
 
   for (auto *Function : MemberFunctions) {
+    isEmpty = false;
     Function->Dump(TypeBuilder, Streamer, TypeSection, StrSection);
+  }
+
+  if (isEmpty) {
+      // If there are no child nodes we need to write an empty record
+    Streamer->emitIntValue(0, 1);
   }
 
   // Terminate DIE


### PR DESCRIPTION
llvm-dwarfdump produces warnings whenever a debugging entry which is specified to have children has no children. The DWARF spec states that any entry specified to contain children should have at least one child, not including the null entry ending the list of children. It also states that a null entry is allowed, in the place of a child entry.

This change adds a null entry in the case that there are no children for the entry.