### PR TITLE
Fix https://github.com/dotnet/runtime/issues/83038

### DIFF
--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfAbbrev.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfAbbrev.cpp
@@ -36,10 +36,10 @@ void Dump(MCObjectStreamer *Streamer, uint16_t DwarfVersion, unsigned TargetPoin
   const uint16_t AbbrevTable[] = {
     CompileUnit,
         dwarf::DW_TAG_compile_unit, dwarf::DW_CHILDREN_yes,
-        dwarf::DW_AT_producer, dwarf::DW_FORM_string,
+        dwarf::DW_AT_producer, dwarf::DW_FORM_strp,
         dwarf::DW_AT_language, dwarf::DW_FORM_data2,
-        dwarf::DW_AT_name, dwarf::DW_FORM_string,
-        dwarf::DW_AT_comp_dir, dwarf::DW_FORM_string,
+        dwarf::DW_AT_name, dwarf::DW_FORM_strp,
+        dwarf::DW_AT_comp_dir, dwarf::DW_FORM_strp,
         dwarf::DW_AT_low_pc, dwarf::DW_FORM_addr,
         dwarf::DW_AT_high_pc, DW_FORM_size,
         dwarf::DW_AT_stmt_list, (DwarfVersion >= 4 ? dwarf::DW_FORM_sec_offset : dwarf::DW_FORM_data4),

--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfGen.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfGen.cpp
@@ -927,6 +927,24 @@ void DwarfGen::EmitCompileUnit() {
     Streamer->emitLabel(AbbrevSectionSymbol);
   }
 
+  // Create strings for producer, name and directory in the compile unit.
+  Streamer->SwitchSection(context.getObjectFileInfo()->getDwarfStrSection());
+
+  MCSymbol *ProducerStrSymbol = context.createTempSymbol();
+  Streamer->emitLabel(ProducerStrSymbol);
+  Streamer->emitBytes(StringRef("NetRuntime"));
+  Streamer->emitIntValue(0, 1);
+
+  MCSymbol *NameStrSymbol = context.createTempSymbol();
+  Streamer->emitLabel(NameStrSymbol);
+  Streamer->emitBytes(StringRef("il.cpp"));
+  Streamer->emitIntValue(0, 1);
+
+  MCSymbol *DirStrSymbol = context.createTempSymbol();
+  Streamer->emitLabel(DirStrSymbol);
+  Streamer->emitBytes(StringRef("/_"));
+  Streamer->emitIntValue(0, 1);
+
   MCSection *debugSection = context.getObjectFileInfo()->getDwarfInfoSection();
   Streamer->SwitchSection(debugSection);
 
@@ -964,9 +982,8 @@ void DwarfGen::EmitCompileUnit() {
   // Abbrev Number
   Streamer->emitULEB128IntValue(DwarfAbbrev::CompileUnit);
 
-  // DW_AT_producer: CoreRT
-  Streamer->emitBytes(StringRef("CoreRT"));
-  Streamer->emitIntValue(0, 1);
+  // DW_AT_producer: NetRuntime
+  DwarfInfo::EmitSectionOffset(Streamer, ProducerStrSymbol, 4);
 
   // DW_AT_language
 #ifdef FEATURE_LANGID_CS
@@ -975,18 +992,16 @@ void DwarfGen::EmitCompileUnit() {
   Streamer->emitIntValue(dwarf::DW_LANG_C_plus_plus, 2);
 #endif
 
-  // We need to generate DW_AT_name and DW_AT_compdir to get Apple's ld64 to correctly
+  // We need to generate DW_AT_name and DW_AT_comp_dir to get Apple's ld64 to correctly
   // generate debug map in final executable. If we don't generate it then the linker
   // will skip over the object file.
   // Ref: https://github.com/apple-oss-distributions/ld64/blob/dbf8f7feb5579761f1623b004bd468bdea7c6225/src/ld/OutputFile.cpp#L7166
 
   // DW_AT_name
-  Streamer->emitBytes(StringRef("IL.c"));
-  Streamer->emitIntValue(0, 1);
+  DwarfInfo::EmitSectionOffset(Streamer, NameStrSymbol, 4);
 
-  // DW_AT_compdir
-  Streamer->emitBytes(StringRef("/tmp"));
-  Streamer->emitIntValue(0, 1);
+  // DW_AT_comp_dir
+  DwarfInfo::EmitSectionOffset(Streamer, DirStrSymbol, 4);
 
   // There need to be global DW_AT_low_pc/DW_AT_high_pc symbols to indicate the base and
   // size of the range covered by the symbols. Currently we use a shortcut where we emit

--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfTypeBuilder.h
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfTypeBuilder.h
@@ -37,16 +37,16 @@ public:
 
   const MCExpr *GetInfoExpr() { return InfoExpr; }
 
+  static void EmitSectionOffset(MCObjectStreamer *Streamer,
+                                MCSymbol *Symbol,
+                                unsigned Size,
+                                uint32_t Offset = 0);
+
 protected:
   virtual void DumpStrings(MCObjectStreamer *Streamer) = 0;
   virtual void DumpTypeInfo(MCObjectStreamer *Streamer, UserDefinedDwarfTypesBuilder *TypeBuilder) = 0;
   virtual bool HasChildren() { return false; }
   virtual void EndChildrenList(MCObjectStreamer *Streamer);
-
-  static void EmitSectionOffset(MCObjectStreamer *Streamer,
-                                MCSymbol *Symbol,
-                                unsigned Size,
-                                uint32_t Offset = 0);
 
   static const MCExpr *CreateOffsetExpr(MCContext &Context,
                                         MCSymbol *BeginSymbol,


### PR DESCRIPTION
Lots of help here from @filipnavara. This changes the DWARF output for the DW_TAG_compile_unit section to use DW_FORM_string (inline C strings) for the DW_AT_name, DW_AT_producer, and DW_AT_comp_dir attributes to use DW_FORM_strp (pointers to string table) output. Despite DW_FORM_string being compliant with the DWARF spec, Apple's ld64 doesn't seem to accept it.

I've also taken the liberty of cleaning up some of the strings while I'm here. The '/_/' directory is our standard 'fake' directory for path mapping, so it seemed appropriate to use here as well.