### PR TITLE
Include llvm-config.exe in Wasi transport packages

### DIFF
--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
@@ -23,6 +23,8 @@
     <File Include="$(_LLVMInstallDir)\bin\lld-link" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-config" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-config.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump" TargetPath="tools\$(PackageTargetRuntime)\bin" />

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
@@ -23,6 +23,8 @@
     <File Include="$(_LLVMInstallDir)\bin\lld-link" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-config" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-config.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump" TargetPath="tools\$(PackageTargetRuntime)\bin" />

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
@@ -22,6 +22,8 @@
     <File Include="$(_LLVMInstallDir)\bin\lld-link.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-config.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-config.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />


### PR DESCRIPTION
Whilst this is not part of the final Wasi SDK build, we need llvm-config during the compiler-rt build in Wasi