### PR TITLE
Add lots more files to transport package (for deletion later)

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -151,16 +151,12 @@
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/c-index-test*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/clang-*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/clangd*" />
-      <FilesToDelete Include="$(_LLVMInstallDir)/bin/count*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/diagtool*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/*dlltool*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/find-all-symbols*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/hmaptool*" />
-      <FilesToDelete Include="$(_LLVMInstallDir)/bin/llvm-PerfectShuffle*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/modularize*" />
-      <FilesToDelete Include="$(_LLVMInstallDir)/bin/not*" />
       <FilesToDelete Include="$(_LLVMInstallDir)/bin/pp-trace*" />
-      <FilesToDelete Include="$(_LLVMInstallDir)/bin/yaml-bench*" />
     </ItemGroup>
     <!-- Files previously marked for removal, which we want exceptions for (i.e. to keep after all) -->
     <ItemGroup>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
@@ -15,44 +15,68 @@
     <File Include="$(_LLVMInstallDir)\bin\clang-format.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\clang-tidy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\clang-tidy.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\count" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\count.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\git-clang-format" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ld.lld" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ld64.lld" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llc" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llc.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld-link" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-as" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-as.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-config" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-config.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-dis" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-dis.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-mc" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-mc.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-nm" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-nm.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objcopy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objcopy.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objdump" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objdump.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-PerfectShuffle" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-PerfectShuffle.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ranlib" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-size" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-size.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strings" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strings.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strip" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-tblgen" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-tblgen.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\nm" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\not" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\not.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\objcopy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\objdump" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\opt.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ranlib" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\run-clang-tidy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\size" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\strings" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\strip" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\wasm-ld" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\yaml-bench" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\yaml-bench.dbg" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\share\**" TargetPath="tools\$(PackageTargetRuntime)\share\%(RecursiveDir)%(Filename)%(Extension)" />
     <File Include="$(_LLVMInstallDir)\lib\clang\**" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\cmake\**" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\libLLVM*.a" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\libobjwriter*so" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
@@ -15,44 +15,68 @@
     <File Include="$(_LLVMInstallDir)\bin\clang-format.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\clang-tidy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\clang-tidy.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\count" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\count.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\git-clang-format" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ld.lld" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ld64.lld" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llc" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llc.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld-link" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-as" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-as.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-config" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-config.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-dis" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-dis.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-mc" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-mc.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-nm" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-nm.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objcopy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objcopy.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objdump" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objdump.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-PerfectShuffle" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-PerfectShuffle.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ranlib" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-size" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-size.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strings" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strings.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strip" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-tblgen" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-tblgen.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\nm" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\not" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\not.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\objcopy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\objdump" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\opt" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\opt.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ranlib" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\run-clang-tidy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\size" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\strings" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\strip" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\wasm-ld" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\yaml-bench" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\yaml-bench.dwarf" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\share\**" TargetPath="tools\$(PackageTargetRuntime)\share\%(RecursiveDir)%(Filename)%(Extension)" />
     <File Include="$(_LLVMInstallDir)\lib\clang\**" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\cmake\**" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\libLLVM*.a" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\libobjwriter*dylib" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport/Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.Transport.props
@@ -14,44 +14,69 @@
     <File Include="$(_LLVMInstallDir)\bin\clang-format.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\clang-tidy.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\clang-tidy.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\count.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\count.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\git-clang-format" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ld.lld.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ld64.lld.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llc.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llc.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\lld-link.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ar.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-as.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-as.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-config.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-config.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-cxxfilt.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-dis.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-dis.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-dwarfdump.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-mc.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-mc.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-mca.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-nm.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-nm.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objcopy.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objcopy.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objdump.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-objdump.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-PerfectShuffle.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-PerfectShuffle.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-ranlib.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-size.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-size.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strings.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strings.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\llvm-strip.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-tblgen.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\llvm-tblgen.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\nm.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\not.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\not.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\objcopy.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\objdump.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\opt.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\opt.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\ranlib.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\run-clang-tidy" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\size.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\strings.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\strip.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\bin\wasm-ld.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\yaml-bench.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\yaml-bench.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck.exe" TargetPath="tools\$(PackageTargetRuntime)\bin" />
+    <File Include="$(_LLVMInstallDir)\bin\FileCheck.pdb" TargetPath="tools\$(PackageTargetRuntime)\bin" />
     <File Include="$(_LLVMInstallDir)\share\**" TargetPath="tools\$(PackageTargetRuntime)\share\%(RecursiveDir)%(Filename)%(Extension)" />
     <File Include="$(_LLVMInstallDir)\lib\clang\**" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\cmake\**" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\libLLVM*.lib" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
+    <File Include="$(_LLVMInstallDir)\lib\libobjwriter*dll" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
LLVMConfig.cmake does a LOT of checking that build files exist, so we need all these extra files in the transport package for LLVMConfig.cmake to work