### PR TITLE
Dynamically link ucrt to objwriter.dll

### DIFF
--- a/llvm/tools/objwriter/CMakeLists.txt
+++ b/llvm/tools/objwriter/CMakeLists.txt
@@ -7,6 +7,11 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
+if (MSVC)
+  # Force uCRT to be dynamically linked for Release build
+  set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+endif()
+
 message(STATUS "ObjWriter configuring with (${CMAKE_BUILD_TYPE}) build type and (${LLVM_DEFAULT_TARGET_TRIPLE}) default target triple")
 
 add_llvm_library(objwriter SHARED

--- a/llvm/tools/objwriter/CMakeLists.txt
+++ b/llvm/tools/objwriter/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-if (MSVC)
+if (MSVC AND (LLVM_USE_CRT_RELEASE STREQUAL "MT"))
   # Force uCRT to be dynamically linked for Release build
   set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
 endif()


### PR DESCRIPTION
Re-apply https://github.com/dotnet/llvm-project/pull/316 that was apparently lost in the transition to main.

Cc @dotnet/ilc-contrib @markples 