### PR TITLE
Fix Windows Clang SDK files.

### DIFF
--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.B.Transport/Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.B.Transport.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.B.Transport/Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.B.Transport.props
@@ -65,7 +65,7 @@
     <File Include="$(_LLVMInstallDir)\share\**" TargetPath="tools\$(PackageTargetRuntime)\share\%(RecursiveDir)\" />
     <File Include="$(_LLVMInstallDir)\lib\clang\**" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\%(RecursiveDir)\" />
     <File Include="$(_LLVMInstallDir)\lib\cmake\**" TargetPath="tools\$(PackageTargetRuntime)\lib\cmake\%(RecursiveDir)\" />
-    <File Include="$(_LLVMInstallDir)\lib\libLLVM*.lib" TargetPath="tools\$(PackageTargetRuntime)\lib\" />
-    <File Include="$(_LLVMInstallDir)\lib\libobjwriter*dll" TargetPath="tools\$(PackageTargetRuntime)\lib\" />
+    <File Include="$(_LLVMInstallDir)\lib\LLVM*.lib" TargetPath="tools\$(PackageTargetRuntime)\lib\" />
+    <File Include="$(_LLVMInstallDir)\lib\objwriter*lib" TargetPath="tools\$(PackageTargetRuntime)\lib\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
LLVM*.lib and objwriter.lib were missing, and causing failures downstream in wasi-sdk.