### PR TITLE
Add support to emit ELF comment section

### DIFF
--- a/llvm/tools/objwriter/objwriter.cpp
+++ b/llvm/tools/objwriter/objwriter.cpp
@@ -228,6 +228,8 @@ MCSection *ObjectWriter::GetSection(const char *SectionName,
     } else {
       Section = ObjFileInfo->getBSSSection();
     } 
+  } else if (strcmp(SectionName, "comment") == 0 && OutContext->getObjectFileType() == MCContext::IsELF) {
+    Section = OutContext->getELFSection(".comment", ELF::SHT_PROGBITS, ELF::SHF_MERGE | ELF::SHF_STRINGS | ELF::SHF_GNU_RETAIN, 1);
   } else {
     Section = GetSpecificSection(SectionName, attributes, ComdatName);
   }


### PR DESCRIPTION
Ref https://github.com/dotnet/runtime/pull/79623

This is required to emit retainable string in comment section (`ELF::SHF_GNU_RETAIN`) which we don't expose on managed side.

cc @jkotas