### PR TITLE
Add support for emitting mono specific EH tables

### DIFF
--- a/llvm/include/llvm/AsmParser/LLToken.h
+++ b/llvm/include/llvm/AsmParser/LLToken.h
@@ -173,6 +173,7 @@ enum Kind {
   kw_amdgpu_kernel,
   kw_amdgpu_gfx,
   kw_tailcc,
+  kw_monocc,
 
   // Attributes:
   kw_attributes,

--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -86,6 +86,9 @@ namespace CallingConv {
     /// their stack.
     SwiftTail = 20,
 
+    // Mono - Calling convention used by Mono
+    Mono = 21,
+
     /// This is the start of the target-specific calling conventions, e.g.
     /// fastcall and thiscall on X86.
     FirstTargetCC = 64,

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -631,6 +631,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(amdgpu_kernel);
   KEYWORD(amdgpu_gfx);
   KEYWORD(tailcc);
+  KEYWORD(monocc);
 
   KEYWORD(cc);
   KEYWORD(c);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -2019,6 +2019,7 @@ void LLParser::parseOptionalDLLStorageClass(unsigned &Res) {
 ///   ::= 'amdgpu_cs'
 ///   ::= 'amdgpu_kernel'
 ///   ::= 'tailcc'
+///   ::= 'monocc'
 ///   ::= 'cc' UINT
 ///
 bool LLParser::parseOptionalCallingConv(unsigned &CC) {
@@ -2077,6 +2078,7 @@ bool LLParser::parseOptionalCallingConv(unsigned &CC) {
   case lltok::kw_amdgpu_cs:      CC = CallingConv::AMDGPU_CS; break;
   case lltok::kw_amdgpu_kernel:  CC = CallingConv::AMDGPU_KERNEL; break;
   case lltok::kw_tailcc:         CC = CallingConv::Tail; break;
+  case lltok::kw_monocc:         CC = CallingConv::Mono; break;
   case lltok::kw_cc: {
       Lex.Lex();
       return parseUInt32(CC);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -566,7 +566,10 @@ bool AsmPrinter::doInitialization(Module &M) {
       break;
     case WinEH::EncodingType::X86:
     case WinEH::EncodingType::Itanium:
-      ES = new WinException(this);
+      if (!EnableMonoEH)
+        ES = new WinException(this);
+      else
+        ES = new WinException(this, true);
       break;
     }
     break;

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -18,6 +18,7 @@
 #include "WasmException.h"
 #include "WinCFGuard.h"
 #include "WinException.h"
+#include "MonoException.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
@@ -144,6 +145,12 @@ const char PPGroupName[] = "pseudo probe";
 const char PPGroupDescription[] = "Pseudo Probe Emission";
 
 STATISTIC(EmittedInsts, "Number of machine instrs printed");
+
+cl::opt<bool> EnableMonoEH("enable-mono-eh-frame", cl::NotHidden,
+     cl::desc("Enable generation of Mono specific EH tables"));
+
+static cl::opt<bool> DisableGNUEH("disable-gnu-eh-frame", cl::NotHidden,
+                                  cl::desc("Disable generation of GNU .eh_frame"));
 
 char AsmPrinter::ID = 0;
 
@@ -545,10 +552,12 @@ bool AsmPrinter::doInitialization(Module &M) {
     [[fallthrough]];
   case ExceptionHandling::SjLj:
   case ExceptionHandling::DwarfCFI:
-    ES = new DwarfCFIException(this);
+    if (!DisableGNUEH)
+      ES = new DwarfCFIException(this);
     break;
   case ExceptionHandling::ARM:
-    ES = new ARMException(this);
+    if (!DisableGNUEH)
+      ES = new ARMException(this);
     break;
   case ExceptionHandling::WinEH:
     switch (MAI->getWinEHEncodingType()) {
@@ -583,6 +592,11 @@ bool AsmPrinter::doInitialization(Module &M) {
     NamedRegionTimer T(HI.TimerName, HI.TimerDescription, HI.TimerGroupName,
                        HI.TimerGroupDescription, TimePassesIsEnabled);
     HI.Handler->beginModule(&M);
+  }
+
+  if (EnableMonoEH) {
+      MonoException *mono_eh = new MonoException (this, DisableGNUEH);
+      Handlers.push_back(HandlerInfo(std::unique_ptr<MonoException> (mono_eh), EHTimerName, EHTimerDescription, DWARFGroupName, DWARFGroupDescription));
   }
 
   return false;
@@ -1614,7 +1628,8 @@ void AsmPrinter::emitFunctionBody() {
 
       switch (MI.getOpcode()) {
       case TargetOpcode::CFI_INSTRUCTION:
-        emitCFIInstruction(MI);
+        if (!EnableMonoEH)
+          emitCFIInstruction(MI);
         break;
       case TargetOpcode::LOCAL_ESCAPE:
         emitFrameAlloc(MI);
@@ -1795,7 +1810,7 @@ void AsmPrinter::emitFunctionBody() {
   // are automatically sized.
   bool EmitFunctionSize = MAI->hasDotTypeDotSizeDirective() && !TT.isWasm();
 
-  if (needFuncLabels(*MF) || EmitFunctionSize) {
+  if (needFuncLabels(*MF) || EmitFunctionSize || EnableMonoEH) {
     // Create a symbol for the end of function.
     CurrentFnEnd = createTempSymbol("func_end");
     OutStreamer->emitLabel(CurrentFnEnd);
@@ -2372,7 +2387,7 @@ void AsmPrinter::SetupMachineFunction(MachineFunction &MF) {
       F.hasFnAttribute("function-instrument") ||
       F.hasFnAttribute("xray-instruction-threshold") ||
       needFuncLabels(MF) || NeedsLocalForSize ||
-      MF.getTarget().Options.EmitStackSizeSection || MF.hasBBLabels()) {
+      MF.getTarget().Options.EmitStackSizeSection || MF.hasBBLabels() || EnableMonoEH) {
     CurrentFnBegin = createTempSymbol("func_begin");
     if (NeedsLocalForSize)
       CurrentFnSymForSize = CurrentFnBegin;

--- a/llvm/lib/CodeGen/AsmPrinter/CMakeLists.txt
+++ b/llvm/lib/CodeGen/AsmPrinter/CMakeLists.txt
@@ -26,6 +26,7 @@ add_llvm_component_library(LLVMAsmPrinter
   WinException.cpp
   CodeViewDebug.cpp
   WasmException.cpp
+  MonoException.cpp
 
   DEPENDS
   intrinsics_gen

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1982,6 +1982,8 @@ void DwarfDebug::collectEntityInfo(DwarfCompileUnit &TheCU,
 
 // Process beginning of an instruction.
 void DwarfDebug::beginInstruction(const MachineInstr *MI) {
+  if (!MMI->hasDebugInfo())
+	  return;
   const MachineFunction &MF = *MI->getMF();
   const auto *SP = MF.getFunction().getSubprogram();
   bool NoDebug =

--- a/llvm/lib/CodeGen/AsmPrinter/MonoException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/MonoException.cpp
@@ -119,7 +119,7 @@ emitCFIInstruction(MCStreamer &Streamer,
     CFAOffset = Instr.getOffset();
     if (CFAOffset < 0) {
       outs () << CFAOffset << "\n";
-      __builtin_trap ();
+      LLVM_BUILTIN_TRAP;
     }
     assert(CFAOffset >= 0);
 

--- a/llvm/lib/CodeGen/AsmPrinter/MonoException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/MonoException.cpp
@@ -26,6 +26,7 @@
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCObjectStreamer.h"
 #include "llvm/MC/MCSection.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
@@ -540,7 +541,7 @@ MonoException::endModule()
   // Emit the EH table
 
   // Can't use rodata as the symbols we reference are in the text segment
-  streamer.SwitchSection(tlof.getTextSection());
+  streamer.switchSection(tlof.getTextSection());
 
   MCSymbol *tableSymbol =
     Asm->OutContext.getOrCreateSymbol(Twine(MonoEHFrameSymbol));
@@ -616,7 +617,7 @@ MonoException::endModule()
   int cieCfaOffset = cfaOffset;
 
   // FDEs
-  streamer.AddBlankLine();
+  streamer.addBlankLine();
   for (std::vector<EHInfo>::iterator
 		   I = Frames.begin(), E = Frames.end(); I != E; ++I) {
 	  const EHInfo &info = *I;
@@ -646,7 +647,7 @@ MonoException::endModule()
       cfaOffset = cieCfaOffset;
       emitCFIInstructions(streamer, info.Instructions, info.BeginSym, &info.EHLabels, cfaOffset, dataAlignmentFactor);
 
-      streamer.AddBlankLine();
+      streamer.addBlankLine();
   }
 
   streamer.emitLabel(tableEndSym);

--- a/llvm/lib/CodeGen/AsmPrinter/MonoException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/MonoException.cpp
@@ -463,8 +463,6 @@ MonoException::EmitMonoLSDA(const EHInfo *info)
           [](const LandingPadInfo *L,
 			 const LandingPadInfo *R) { return L->TypeIds < R->TypeIds; });
 
-  assert(Asm->MAI->getExceptionHandlingType() == ExceptionHandling::DwarfCFI);
-
   // The type_info itself is emitted
   int TTypeEncoding = dwarf::DW_EH_PE_udata4;
 

--- a/llvm/lib/CodeGen/AsmPrinter/MonoException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/MonoException.cpp
@@ -1,0 +1,675 @@
+//===---*- mode: c++; indent-tabs-mode: nil; c-basic-offset: 2 -*---------===//
+//===-- CodeGen/AsmPrinter/MonoException.cpp - Dwarf Exception Impl ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains code to emit Mono specific exception handling tables.
+// It is based on code in DwarfException.cpp and MCDwarf.cpp.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MonoException.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/CodeGen/AsmPrinter.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineFrameInfo.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/CodeGen/TargetFrameLowering.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCSection.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCSymbolELF.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetOptions.h"
+#include "llvm/Target/TargetLoweringObjectFile.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FormattedStream.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
+using namespace llvm;
+
+//
+// The EH tables emitted by this class enable the following functionality:
+// - obtaining the GNU EH information for a given method
+// - obtaining the DWARF CFI unwind info for a given method
+// - obtaining the address of the table itself from user
+//   code, ie. it is in the text segment pointed to by
+//   a symbol.
+//
+
+cl::opt<std::string> MonoEHFrameSymbol("mono-eh-frame-symbol", cl::NotHidden,
+                                       cl::desc("Symbol name for the mono eh frame"));
+
+// Emit a CFI instruction in DWARF format
+static void
+emitCFIInstruction(MCStreamer &Streamer,
+                   const MCCFIInstruction &Instr,
+                   int &CFAOffset, int DataAlignmentFactor)
+{
+  // Same as MCDwarf::EmitCFIInstruction ()
+  // FIXME: Unify
+  int dataAlignmentFactor = DataAlignmentFactor;
+  bool VerboseAsm = Streamer.isVerboseAsm();
+
+  switch (Instr.getOperation()) {
+  case MCCFIInstruction::OpWindowSave: {
+    Streamer.emitIntValue(dwarf::DW_CFA_GNU_window_save, 1);
+    return;
+  }
+  case MCCFIInstruction::OpUndefined: {
+    unsigned Reg = Instr.getRegister();
+    if (VerboseAsm) {
+      Streamer.AddComment("DW_CFA_undefined");
+      Streamer.AddComment(Twine("Reg ") + Twine(Reg));
+    }
+    Streamer.emitIntValue(dwarf::DW_CFA_undefined, 1);
+    Streamer.emitULEB128IntValue(Reg);
+    return;
+  }
+  case MCCFIInstruction::OpAdjustCfaOffset:
+  case MCCFIInstruction::OpDefCfaOffset: {
+    const bool IsRelative =
+      Instr.getOperation() == MCCFIInstruction::OpAdjustCfaOffset;
+
+    if (VerboseAsm)
+      Streamer.AddComment("DW_CFA_def_cfa_offset");
+    Streamer.emitIntValue(dwarf::DW_CFA_def_cfa_offset, 1);
+
+    if (IsRelative) {
+      CFAOffset += Instr.getOffset();
+    } else {
+      // The backends pass in a negative value,
+      // then createDefCfaOffset () negates it
+      CFAOffset = Instr.getOffset();
+      assert(CFAOffset >= 0);
+    }
+
+    if (VerboseAsm)
+      Streamer.AddComment(Twine("Offset " + Twine(CFAOffset)));
+    Streamer.emitULEB128IntValue(CFAOffset);
+
+    return;
+  }
+  case MCCFIInstruction::OpDefCfa: {
+    if (VerboseAsm)
+      Streamer.AddComment("DW_CFA_def_cfa");
+    Streamer.emitIntValue(dwarf::DW_CFA_def_cfa, 1);
+
+    if (VerboseAsm)
+      Streamer.AddComment(Twine("Reg ") + Twine(Instr.getRegister()));
+    Streamer.emitULEB128IntValue(Instr.getRegister());
+
+    // The backends pass in a negative value,
+    // then createDefCfaOffset () negates it
+    CFAOffset = Instr.getOffset();
+    if (CFAOffset < 0) {
+      outs () << CFAOffset << "\n";
+      __builtin_trap ();
+    }
+    assert(CFAOffset >= 0);
+
+    if (VerboseAsm)
+      Streamer.AddComment(Twine("Offset " + Twine(CFAOffset)));
+    Streamer.emitULEB128IntValue(CFAOffset);
+
+    return;
+  }
+
+  case MCCFIInstruction::OpDefCfaRegister: {
+    if (VerboseAsm)
+      Streamer.AddComment("DW_CFA_def_cfa_register");
+    Streamer.emitIntValue(dwarf::DW_CFA_def_cfa_register, 1);
+
+    if (VerboseAsm)
+      Streamer.AddComment(Twine("Reg ") + Twine(Instr.getRegister()));
+    Streamer.emitULEB128IntValue(Instr.getRegister());
+
+    return;
+  }
+
+  case MCCFIInstruction::OpOffset:
+  case MCCFIInstruction::OpRelOffset: {
+    const bool IsRelative =
+      Instr.getOperation() == MCCFIInstruction::OpRelOffset;
+
+    unsigned Reg = Instr.getRegister();
+    int Offset = Instr.getOffset();
+    if (IsRelative)
+      Offset -= CFAOffset;
+    Offset = Offset / dataAlignmentFactor;
+
+    if (Offset < 0) {
+      if (VerboseAsm) Streamer.AddComment("DW_CFA_offset_extended_sf");
+      Streamer.emitIntValue(dwarf::DW_CFA_offset_extended_sf, 1);
+      if (VerboseAsm) Streamer.AddComment(Twine("Reg ") + Twine(Reg));
+      Streamer.emitULEB128IntValue(Reg);
+      if (VerboseAsm) Streamer.AddComment(Twine("Offset ") + Twine(Offset));
+      Streamer.emitSLEB128IntValue(Offset);
+    } else if (Reg < 64) {
+      if (VerboseAsm) Streamer.AddComment(Twine("DW_CFA_offset + Reg(") +
+                                          Twine(Reg) + ")");
+      Streamer.emitIntValue(dwarf::DW_CFA_offset + Reg, 1);
+      if (VerboseAsm) Streamer.AddComment(Twine("Offset ") + Twine(Offset));
+      Streamer.emitULEB128IntValue(Offset);
+    } else {
+      if (VerboseAsm) Streamer.AddComment("DW_CFA_offset_extended");
+      Streamer.emitIntValue(dwarf::DW_CFA_offset_extended, 1);
+      if (VerboseAsm) Streamer.AddComment(Twine("Reg ") + Twine(Reg));
+      Streamer.emitULEB128IntValue(Reg);
+      if (VerboseAsm) Streamer.AddComment(Twine("Offset ") + Twine(Offset));
+      Streamer.emitULEB128IntValue(Offset);
+    }
+    return;
+  }
+  case MCCFIInstruction::OpRememberState:
+    if (VerboseAsm) Streamer.AddComment("DW_CFA_remember_state");
+    Streamer.emitIntValue(dwarf::DW_CFA_remember_state, 1);
+    return;
+  case MCCFIInstruction::OpRestoreState:
+    if (VerboseAsm) Streamer.AddComment("DW_CFA_restore_state");
+    Streamer.emitIntValue(dwarf::DW_CFA_restore_state, 1);
+    return;
+  case MCCFIInstruction::OpSameValue: {
+    unsigned Reg = Instr.getRegister();
+    if (VerboseAsm) Streamer.AddComment("DW_CFA_same_value");
+    Streamer.emitIntValue(dwarf::DW_CFA_same_value, 1);
+    if (VerboseAsm) Streamer.AddComment(Twine("Reg ") + Twine(Reg));
+    Streamer.emitULEB128IntValue(Reg);
+    return;
+  }
+  case MCCFIInstruction::OpRestore: {
+    unsigned Reg = Instr.getRegister();
+    if (VerboseAsm) {
+      Streamer.AddComment("DW_CFA_restore");
+      Streamer.AddComment(Twine("Reg ") + Twine(Reg));
+    }
+    Streamer.emitIntValue(dwarf::DW_CFA_restore | Reg, 1);
+    return;
+  }
+  case MCCFIInstruction::OpEscape:
+    if (VerboseAsm) Streamer.AddComment("Escape bytes");
+    Streamer.emitBytes(Instr.getValues());
+    return;
+  case MCCFIInstruction::OpRegister:
+  case MCCFIInstruction::OpGnuArgsSize:
+	  llvm_unreachable("Unhandled case in switch");	
+	  return;
+  default:
+    break;
+  }
+  llvm_unreachable("Unhandled case in switch");
+}
+
+// Emit a list of CFI instructions
+static void
+emitCFIInstructions(MCStreamer &streamer,
+                    const std::vector<MCCFIInstruction> &Instrs,
+                    MCSymbol *BaseLabel,
+                    const std::vector<MCSymbol*> *Labels,
+                    int &CFAOffset,
+                    int DataAlignmentFactor)
+{
+  for (unsigned i = 0, N = Instrs.size(); i < N; ++i) {
+    const MCCFIInstruction &Instr = Instrs[i];
+    MCSymbol *Label = Labels ? ((*Labels)[i]) : NULL;
+
+    // Advance row if new location.
+    if (BaseLabel && Label) {
+      MCSymbol *ThisSym = Label;
+      if (ThisSym != BaseLabel) {
+        streamer.AddComment ("cfa_advance");
+        streamer.emitDwarfAdvanceFrameAddr(BaseLabel, ThisSym);
+        BaseLabel = ThisSym;
+      }
+    }
+
+    emitCFIInstruction(streamer, Instr, CFAOffset, DataAlignmentFactor);
+  }
+}
+
+MonoException::MonoException(AsmPrinter *A, bool disableGNUEH)
+  : EHStreamer(A)
+{
+  RI = nullptr;
+  DisableGNUEH = disableGNUEH;
+}
+
+MonoException::~MonoException()
+{
+}
+
+void
+MonoException::beginFunction(const MachineFunction *MF)
+{
+  EmitFnStart();
+  EHLabels.clear();
+}
+
+void
+MonoException::PrepareMonoLSDA(EHInfo *info)
+{
+  const MachineFunction *MF = Asm->MF;
+  const std::vector<const GlobalValue *> &TypeInfos = MF->getTypeInfos();
+  const std::vector<LandingPadInfo> &PadInfos = MF->getLandingPads();
+
+  // Sort the landing pads in order of their type ids.  This is used to fold
+  // duplicate actions.
+  SmallVector<const LandingPadInfo *, 64> LandingPads;
+  LandingPads.reserve(PadInfos.size());
+
+  for (unsigned i = 0, N = PadInfos.size(); i != N; ++i)
+    LandingPads.push_back(&PadInfos[i]);
+
+  std::sort(LandingPads.begin(), LandingPads.end(),
+          [](const LandingPadInfo *L,
+			 const LandingPadInfo *R) { return L->TypeIds < R->TypeIds; });
+
+  // Invokes and nounwind calls have entries in PadMap (due to being bracketed
+  // by try-range labels when lowered).  Ordinary calls do not, so appropriate
+  // try-ranges for them need be deduced when using DWARF exception handling.
+  RangeMapType PadMap;
+  for (unsigned i = 0, N = LandingPads.size(); i != N; ++i) {
+    const LandingPadInfo *LandingPad = LandingPads[i];
+    for (unsigned j = 0, E = LandingPad->BeginLabels.size(); j != E; ++j) {
+      MCSymbol *BeginLabel = LandingPad->BeginLabels[j];
+      assert(!PadMap.count(BeginLabel) && "Duplicate landing pad labels!");
+      PadRange P = { i, j };
+      PadMap[BeginLabel] = P;
+    }
+  }
+
+  // Compute the call-site table.
+  SmallVector<MonoCallSiteEntry, 64> CallSites;
+
+  MCSymbol *LastLabel = 0;
+  for (MachineFunction::const_iterator I = MF->begin(), E = MF->end();
+        I != E; ++I) {
+    for (MachineBasicBlock::const_iterator MI = I->begin(), E = I->end();
+          MI != E; ++MI) {
+      if (!MI->isLabel()) {
+        continue;
+      }
+
+      MCSymbol *BeginLabel = MI->getOperand(0).getMCSymbol();
+      assert(BeginLabel && "Invalid label!");
+
+      RangeMapType::iterator L = PadMap.find(BeginLabel);
+
+      if (L == PadMap.end())
+        continue;
+
+      PadRange P = L->second;
+      const LandingPadInfo *LandingPad = LandingPads[P.PadIndex];
+
+      assert(BeginLabel == LandingPad->BeginLabels[P.RangeIndex] &&
+              "Inconsistent landing pad map!");
+
+      // Mono emits one landing pad for each CLR exception clause,
+      // and the type info contains the clause index
+      assert (LandingPad->TypeIds.size() == 1);
+      assert (LandingPad->LandingPadLabel);
+
+      LastLabel = LandingPad->EndLabels[P.RangeIndex];
+      MonoCallSiteEntry Site = {BeginLabel, LastLabel,
+							LandingPad->LandingPadLabel, LandingPad->TypeIds [0]};
+
+      assert(Site.BeginLabel && Site.EndLabel && Site.PadLabel &&
+              "Invalid landing pad!");
+
+	  // FIXME: This doesn't work because it includes ranges outside clauses
+#if 0
+      // Try to merge with the previous call-site.
+      if (CallSites.size()) {
+        MonoCallSiteEntry &Prev = CallSites.back();
+        if (Site.PadLabel == Prev.PadLabel && Site.TypeID == Prev.TypeID) {
+          // Extend the range of the previous entry.
+          Prev.EndLabel = Site.EndLabel;
+          continue;
+        }
+      }
+#endif
+
+      // Otherwise, create a new call-site.
+      CallSites.push_back(Site);
+    }
+  }
+
+  info->CallSites.insert(info->CallSites.begin(), CallSites.begin(), CallSites.end());
+  info->TypeInfos = TypeInfos;
+  info->PadInfos = PadInfos;
+
+  int ThisSlot = Asm->MF->getMonoThisSlot();
+
+  if (ThisSlot != -1) {
+    llvm::Register FrameReg;
+    info->ThisOffset = Asm->MF->getTarget ().getSubtargetImpl (Asm->MF->getFunction())->getFrameLowering ()->getFrameIndexReference (*Asm->MF, ThisSlot, FrameReg).getFixed ();
+    info->FrameReg = Asm->MF->getTarget ().getSubtargetImpl (Asm->MF->getFunction())->getRegisterInfo ()->getDwarfRegNum (FrameReg, true);
+  } else {
+    info->FrameReg = -1;
+  }
+}
+
+void
+MonoException::EmitFnStart(void)
+{
+  if (DisableGNUEH && Asm->MAI->getExceptionHandlingType() == ExceptionHandling::ARM)
+    static_cast<ARMTargetStreamer*>(Asm->OutStreamer->getTargetStreamer())->emitFnStart();
+}
+
+void
+MonoException::EmitFnEnd(void)
+{
+  if (DisableGNUEH && Asm->MAI->getExceptionHandlingType() == ExceptionHandling::ARM)
+    static_cast<ARMTargetStreamer*>(Asm->OutStreamer->getTargetStreamer())->emitFnEnd();
+}
+
+void
+MonoException::endFunction(const MachineFunction *MF)
+{
+  //
+  // Compute a mapping from method names to their AOT method index
+  //
+  if (FuncIndexes.size () == 0) {
+    const Module *m = MMI->getModule ();
+    NamedMDNode *indexes = m->getNamedMetadata ("mono.function_indexes");
+	if (indexes) {
+      for (unsigned int i = 0; i < indexes->getNumOperands (); ++i) {
+        MDNode *n = indexes->getOperand (i);
+        MDString *s = cast<MDString>(n->getOperand (0));
+        auto *idx = mdconst::dyn_extract<ConstantInt>(n->getOperand (1));
+        FuncIndexes.insert (std::make_pair(s->getString (), (int)idx->getLimitedValue () + 1));
+      }
+    }
+  }
+
+  // Remember the register info
+  RI = MF->getSubtarget().getRegisterInfo();
+
+  MachineFunction *NonConstMF = const_cast<MachineFunction*>(MF);
+  NonConstMF->tidyLandingPads();
+
+  int monoMethodIdx = FuncIndexes.lookup (Asm->MF->getFunction ().getName ()) - 1;
+
+  if (monoMethodIdx == -1) {
+    EmitFnEnd ();
+    return;
+  }
+
+  //outs () << "D: " << Asm->MF->getFunction()->getName() << " " << monoMethodIdx << "\n";
+
+  // Save information for use by endModule ()
+  EHInfo info;
+
+  info.FunctionNumber = Asm->getFunctionNumber();
+  info.BeginSym = Asm->getFunctionBegin ();
+  info.EndSym = Asm->getFunctionEnd ();
+  info.EHLabels = EHLabels;
+  info.MonoMethodIdx = monoMethodIdx;
+  info.HasLandingPads = !MF->getLandingPads().empty();
+  info.Instructions = MF->getFrameInstructions();
+  assert (info.Instructions.size () == info.EHLabels.size());
+
+  if (DisableGNUEH)
+    /* ARMAsmPrinter generates references to this */
+    Asm->OutStreamer->emitLabel(Asm->getMBBExceptionSym(MF->front()));
+
+  PrepareMonoLSDA(&info);
+
+  Frames.push_back(info);
+  EHLabels.clear();
+
+  EmitFnEnd ();
+}
+
+/// EmitMonoLSDA - Mono's version of EmitExceptionTable
+///
+/// The code below is a modified/simplified version of DwarfException::EmitExceptionTable()
+/// We emit the information inline instead of into a separate section.
+///
+void
+MonoException::EmitMonoLSDA(const EHInfo *info)
+{
+  // Load saved information from EHFrameInfo
+  const std::vector<const GlobalValue *> &TypeInfos = info->TypeInfos;
+  const std::vector<LandingPadInfo> &PadInfos = info->PadInfos;
+  const std::vector<MonoCallSiteEntry> CallSites = info->CallSites;
+  int FrameReg = info->FrameReg;
+  int ThisOffset = info->ThisOffset;
+
+  // Sort the landing pads in order of their type ids.  This is used to fold
+  // duplicate actions.
+  SmallVector<const LandingPadInfo *, 64> LandingPads;
+  LandingPads.reserve(PadInfos.size());
+
+  for (unsigned i = 0, N = PadInfos.size(); i != N; ++i)
+    LandingPads.push_back(&PadInfos[i]);
+
+  std::sort(LandingPads.begin(), LandingPads.end(),
+          [](const LandingPadInfo *L,
+			 const LandingPadInfo *R) { return L->TypeIds < R->TypeIds; });
+
+  assert(Asm->MAI->getExceptionHandlingType() == ExceptionHandling::DwarfCFI);
+
+  // The type_info itself is emitted
+  int TTypeEncoding = dwarf::DW_EH_PE_udata4;
+
+  // Emit the LSDA.
+  // Keep this in sync with JITDwarfEmitter::EmitExceptionTable ()
+  Asm->emitULEB128(0x4d4fef4f, "MONO Magic");
+  Asm->emitULEB128(1, "Version");
+
+  // Emit the LSDA header.
+  if (FrameReg != -1) {
+    Asm->emitEncodingByte(dwarf::DW_EH_PE_udata4, "This encoding");
+
+    // Emit 'this' location
+    Asm->OutStreamer->AddComment("bregx");
+    Asm->emitInt8((int)dwarf::DW_OP_bregx);
+    Asm->emitULEB128(FrameReg, "Base reg");
+    Asm->emitSLEB128(ThisOffset, "Offset");
+  } else {
+    Asm->emitEncodingByte(dwarf::DW_EH_PE_omit, "@This encoding");
+  }
+
+  Asm->emitULEB128 (CallSites.size (), "Number of call sites");
+  Asm->emitAlignment(llvm::Align(4));
+  for (std::vector<MonoCallSiteEntry>::const_iterator
+         I = CallSites.begin(), E = CallSites.end(); I != E; ++I) {
+    const MonoCallSiteEntry &S = *I;
+      
+    MCSymbol *EHFuncBeginSym = info->BeginSym;
+      
+    MCSymbol *BeginLabel = S.BeginLabel;
+    if (BeginLabel == 0)
+      BeginLabel = EHFuncBeginSym;
+    MCSymbol *EndLabel = S.EndLabel;
+    if (EndLabel == 0)
+      EndLabel = info->EndSym;
+        
+    Asm->OutStreamer->AddComment("Region start");
+    Asm->emitLabelDifference(BeginLabel, EHFuncBeginSym, 4);
+      
+    Asm->OutStreamer->AddComment("Region length");
+    Asm->emitLabelDifference(EndLabel, BeginLabel, 4);
+
+    Asm->OutStreamer->AddComment("Landing pad");
+    if (!S.PadLabel)
+      Asm->OutStreamer->emitIntValue(0, 4);
+    else
+      Asm->emitLabelDifference(S.PadLabel, EHFuncBeginSym, 4);
+
+	unsigned int TypeID = S.TypeID;
+    assert (TypeID > 0 && TypeID <= TypeInfos.size ());
+    const GlobalVariable *GV = dyn_cast<GlobalVariable>(TypeInfos[TypeID - 1]);
+    assert (GV);
+
+    //
+    // Mono typeinfos are simple constant integers. Emit the constant itself.
+    //
+    assert(GV);
+    const ConstantInt *ci = dyn_cast<ConstantInt>(GV->getInitializer());
+
+    Asm->OutStreamer->AddComment("TypeInfo");
+    Asm->OutStreamer->emitIntValue(ci->getZExtValue(),Asm->GetSizeOfEncodedValue(TTypeEncoding));
+  }
+}
+
+void
+MonoException::endModule()
+{
+  const TargetLoweringObjectFile &tlof = Asm->getObjFileLowering();
+  auto &streamer = *Asm->OutStreamer;
+
+  // Size and sign of stack growth.
+  int stackGrowth = -Asm->getDataLayout().getPointerSize();
+  int dataAlignmentFactor = stackGrowth;
+
+  // Emit the EH table
+
+  // Can't use rodata as the symbols we reference are in the text segment
+  streamer.SwitchSection(tlof.getTextSection());
+
+  MCSymbol *tableSymbol =
+    Asm->OutContext.getOrCreateSymbol(Twine(MonoEHFrameSymbol));
+  MCSymbol *tableEndSym = Asm->createTempSymbol ("mono_eh_frame_end");
+
+  // Symbol
+  Asm->emitAlignment(llvm::Align(16));
+  streamer.emitLabel(tableSymbol);
+  streamer.emitSymbolAttribute(tableSymbol, MCSA_ELF_TypeObject);
+  if (Asm->MAI->hasDotTypeDotSizeDirective()) {
+    const MCExpr *SizeExp = MCBinaryExpr::createSub(
+        MCSymbolRefExpr::create(tableEndSym, Asm->OutContext),
+        MCSymbolRefExpr::create(tableSymbol, Asm->OutContext), Asm->OutContext);
+    streamer.emitELFSize(cast<MCSymbolELF>(tableSymbol), SizeExp);
+  }
+
+  // Header
+  streamer.AddComment("version");
+  streamer.emitIntValue(3, 1);
+  streamer.AddComment ("func addr encoding");
+  // Unused
+  streamer.emitIntValue (0, 1);
+
+  // Search table
+  Asm->emitAlignment(llvm::Align(4));
+  streamer.AddComment("fde_count");
+  streamer.emitIntValue (Frames.size(), 4);
+
+  MCSymbol *lastBegin = nullptr;
+  MCSymbol *lastEnd = nullptr;
+  for (std::vector<EHInfo>::iterator
+		   I = Frames.begin(), E = Frames.end(); I != E; ++I) {
+	  EHInfo &info = *I;
+
+      info.FDESym = Asm->createTempSymbol ("mono_fde");
+
+      streamer.AddComment("mono method idx");
+      streamer.emitIntValue (info.MonoMethodIdx, 4);
+
+	  Asm->emitLabelDifference(info.FDESym, tableSymbol, 4);
+      lastBegin = info.BeginSym;
+      lastEnd = info.EndSym;
+  }
+
+  // Emit a last entry to simplify binary searches and to enable the computation of
+  // the size of the last function/FDE entry
+  if (Frames.size() == 0) {
+	  streamer.emitIntValue (-1, 4);
+	  Asm->emitLabelDifference(tableSymbol, tableSymbol, 4);
+  } else {
+	  // Emit the size of the last function, since it cannot be computed using the next table entry
+	  Asm->emitLabelDifference(lastEnd, lastBegin, 4);
+	  Asm->emitLabelDifference(tableEndSym, tableSymbol, 4);
+  }
+
+  // CIE
+  // This comes right after the search table
+  Asm->emitULEB128(1, "CIE Code Alignment Factor");
+  Asm->emitSLEB128(stackGrowth, "CIE Data Alignment Factor");
+  streamer.AddComment("CIE Return Address Column");
+  // RI can be null if there are no methods
+  if (RI)
+    Asm->emitInt8(RI->getDwarfRegNum(RI->getRARegister(), true));
+  Asm->emitEncodingByte(dwarf::DW_EH_PE_omit, "Personality");
+
+  int cfaOffset = 0;
+
+  // Initial CIE program
+  emitCFIInstructions(streamer, streamer.getContext().getAsmInfo()->getInitialFrameState(), NULL, NULL, cfaOffset, stackGrowth);
+  streamer.AddComment("End of CIE program");
+  streamer.emitIntValue(dwarf::DW_CFA_nop, 1);
+
+  int cieCfaOffset = cfaOffset;
+
+  // FDEs
+  streamer.AddBlankLine();
+  for (std::vector<EHInfo>::iterator
+		   I = Frames.begin(), E = Frames.end(); I != E; ++I) {
+	  const EHInfo &info = *I;
+
+      streamer.emitLabel(info.FDESym);
+
+      // Emit augmentation
+      if (info.HasLandingPads || info.FrameReg != -1) {
+        // Need an extra has_augmentation field as the augmentation size is always encoded
+        // in 4 bytes
+        Asm->emitULEB128(1, "Has augmentation");
+
+        MCSymbol *fdeBeginSym = Asm->OutContext.createTempSymbol("mono_fde_aug_begin", info.FunctionNumber);
+        MCSymbol *fdeEndSym = Asm->OutContext.createTempSymbol("mono_fde_aug_end", info.FunctionNumber);
+
+        streamer.AddComment("Augmentation size");
+        Asm->emitLabelDifference(fdeEndSym, fdeBeginSym, 4);
+
+        streamer.emitLabel(fdeBeginSym);
+        EmitMonoLSDA (&info);
+        streamer.emitLabel(fdeEndSym);
+      } else {
+        Asm->emitULEB128(0, "Has augmentation");
+      }
+
+      // Emit unwind info
+      cfaOffset = cieCfaOffset;
+      emitCFIInstructions(streamer, info.Instructions, info.BeginSym, &info.EHLabels, cfaOffset, dataAlignmentFactor);
+
+      streamer.AddBlankLine();
+  }
+
+  streamer.emitLabel(tableEndSym);
+  Asm->emitAlignment(llvm::Align(8));
+}
+
+void
+MonoException::beginInstruction(const MachineInstr *MI)
+{
+	if (MI->getOpcode() == TargetOpcode::CFI_INSTRUCTION) {
+		unsigned CFIIndex = MI->getOperand(0).getCFIIndex();
+
+		//outs () << "D: " << CFIIndex << " " << EHLabels.size() << "\n";
+
+		/* Emit a label and save the label-cfi index association */
+		if (CFIIndex != EHLabels.size())
+			assert (0);
+
+		MCSymbol *Label = Asm->OutContext.createTempSymbol();
+		Asm->OutStreamer->emitLabel(Label);
+
+		EHLabels.push_back(Label);
+	}
+}

--- a/llvm/lib/CodeGen/AsmPrinter/MonoException.h
+++ b/llvm/lib/CodeGen/AsmPrinter/MonoException.h
@@ -1,0 +1,82 @@
+//===---*- mode: c++; indent-tabs-mode: nil -*----------------------------===//
+//===-- MonoException.h - Dwarf Exception Framework -----------*- C++ -*--===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+
+#ifndef LLVM_LIB_CODEGEN_ASMPRINTER_MONOEXCEPTION_H
+#define LLVM_LIB_CODEGEN_ASMPRINTER_MONOEXCEPTION_H
+
+#include "EHStreamer.h"
+#include "llvm/CodeGen/AsmPrinter.h"
+
+namespace llvm {
+
+class TargetRegisterInfo;
+
+class MonoException : public EHStreamer {
+public:
+  MonoException(AsmPrinter *A, bool disableGNUEH);
+  virtual ~MonoException();
+
+  void endModule() override;
+
+  void beginFunction(const MachineFunction *MF) override;
+
+  void endFunction(const MachineFunction *) override;
+
+  void beginInstruction(const MachineInstr *MI) override;
+private:
+
+  struct MonoCallSiteEntry {
+    // The 'try-range' is BeginLabel .. EndLabel.
+    MCSymbol *BeginLabel; // zero indicates the start of the function.
+    MCSymbol *EndLabel;   // zero indicates the end of the function.
+
+    // The landing pad starts at PadLabel.
+    MCSymbol *PadLabel;   // zero indicates that there is no landing pad.
+    int TypeID;
+  };
+
+  // Per-function EH info
+  struct EHInfo {
+    int FunctionNumber, MonoMethodIdx;
+	MCSymbol *BeginSym, *EndSym, *FDESym;
+	std::vector<MCSymbol*> EHLabels;
+    std::vector<MCCFIInstruction> Instructions;
+    std::vector<MonoCallSiteEntry> CallSites;
+    std::vector<const GlobalValue *> TypeInfos;
+    std::vector<LandingPadInfo> PadInfos;
+    int FrameReg;
+    int ThisOffset;
+    bool HasLandingPads;
+
+    EHInfo() {
+      FunctionNumber = 0;
+      MonoMethodIdx = 0;
+      BeginSym = nullptr;
+      EndSym = nullptr;
+      FrameReg = -1;
+      ThisOffset = 0;
+      HasLandingPads = 0;
+    }
+  };
+
+  void PrepareMonoLSDA(EHInfo *info);
+  void EmitMonoLSDA(const EHInfo *info);
+  void EmitFnStart();
+  void EmitFnEnd();
+
+  std::vector<MCSymbol*> EHLabels;
+  std::vector<EHInfo> Frames;
+  StringMap<int> FuncIndexes;
+  const TargetRegisterInfo *RI;
+  bool DisableGNUEH;
+};
+} // End of namespace llvm
+
+#endif
+

--- a/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
@@ -85,9 +85,11 @@ void WinException::beginFunction(const MachineFunction *MF) {
                               !isNoOpWithoutInvoke(Per) &&
                               F.needsUnwindTableEntry();
 
-  shouldEmitPersonality =
-      forceEmitPersonality || ((hasLandingPads || hasEHFunclets) &&
-                               PerEncoding != dwarf::DW_EH_PE_omit && PerFn);
+  if (!disableEmitPersonality) {
+    shouldEmitPersonality =
+        forceEmitPersonality || ((hasLandingPads || hasEHFunclets) &&
+                                 PerEncoding != dwarf::DW_EH_PE_omit && PerFn);
+  }
 
   unsigned LSDAEncoding = TLOF.getLSDAEncoding();
   shouldEmitLSDA = shouldEmitPersonality &&

--- a/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
@@ -40,6 +40,13 @@ WinException::WinException(AsmPrinter *A) : EHStreamer(A) {
   isThumb = Asm->TM.getTargetTriple().isThumb();
 }
 
+WinException::WinException(AsmPrinter *A, bool disableEmitPersonality)
+: EHStreamer(A), disableEmitPersonality(disableEmitPersonality) {
+  // MSVC's EH tables are always composed of 32-bit words.  All known 64-bit
+  // platforms use an imagerel32 relocation to refer to symbols.
+  useImageRel32 = (A->getDataLayout().getPointerSizeInBits() == 64);
+}
+
 WinException::~WinException() = default;
 
 /// endModule - Emit all exception information that should come after the

--- a/llvm/lib/CodeGen/AsmPrinter/WinException.h
+++ b/llvm/lib/CodeGen/AsmPrinter/WinException.h
@@ -33,6 +33,9 @@ class LLVM_LIBRARY_VISIBILITY WinException : public EHStreamer {
   /// Per-function flag to indicate if frame moves info should be emitted.
   bool shouldEmitMoves = false;
 
+  /// Per-function flag to indicate if personality info should be disabled.
+  bool disableEmitPersonality = false;
+
   /// True if this is a 64-bit target and we should use image relative offsets.
   bool useImageRel32 = false;
 
@@ -97,6 +100,7 @@ public:
   // Main entry points.
   //
   WinException(AsmPrinter *A);
+  WinException(AsmPrinter *A, bool disableEmitPersonality);
   ~WinException() override;
 
   /// Emit all exception information that should come after the content.

--- a/llvm/lib/CodeGen/FaultMaps.cpp
+++ b/llvm/lib/CodeGen/FaultMaps.cpp
@@ -15,8 +15,15 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
+
+static cl::opt<bool> DisableFaultMaps("disable-fault-maps",
+  cl::desc("Disables emission of fault map metadata."),
+  cl::init(false), cl::Hidden);
 
 #define DEBUG_TYPE "faultmaps"
 
@@ -43,6 +50,8 @@ void FaultMaps::recordFaultingOp(FaultKind FaultTy,
 }
 
 void FaultMaps::serializeToFaultMapSection() {
+  if (DisableFaultMaps)
+    return;
   if (FunctionInfos.empty())
     return;
 

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -340,6 +340,7 @@ static void PrintCallingConv(unsigned cc, raw_ostream &Out) {
   case CallingConv::AMDGPU_CS:     Out << "amdgpu_cs"; break;
   case CallingConv::AMDGPU_KERNEL: Out << "amdgpu_kernel"; break;
   case CallingConv::AMDGPU_Gfx:    Out << "amdgpu_gfx"; break;
+  case CallingConv::Mono:          Out << "monocc"; break;
   }
 }
 

--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.h
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.h
@@ -49,6 +49,12 @@ bool RetCC_AArch64_AAPCS(unsigned ValNo, MVT ValVT, MVT LocVT,
 bool RetCC_AArch64_WebKit_JS(unsigned ValNo, MVT ValVT, MVT LocVT,
                              CCValAssign::LocInfo LocInfo,
                              ISD::ArgFlagsTy ArgFlags, CCState &State);
+bool CC_AArch64_Mono_DarwinPCS(unsigned ValNo, MVT ValVT, MVT LocVT,
+                          CCValAssign::LocInfo LocInfo,
+                          ISD::ArgFlagsTy ArgFlags, CCState &State);
+bool CC_AArch64_Mono_AAPCS(unsigned ValNo, MVT ValVT, MVT LocVT,
+                      CCValAssign::LocInfo LocInfo, ISD::ArgFlagsTy ArgFlags,
+                      CCState &State);
 } // namespace llvm
 
 #endif

--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -567,3 +567,28 @@ def CSR_AArch64_SVE_AAPCS_SCS
     : CalleeSavedRegs<(add CSR_AArch64_SVE_AAPCS, X18)>;
 def CSR_AArch64_AAPCS_SCS
     : CalleeSavedRegs<(add CSR_AArch64_AAPCS, X18)>;
+
+//===----------------------------------------------------------------------===//
+// AARCH64 Mono calling conventions
+//===----------------------------------------------------------------------===//
+
+let Entry = 1 in
+def CC_AArch64_Mono_DarwinPCS : CallingConv<[
+
+  // Mono marks the parameter it wants to pass in this non-abi register with
+  // the 'inreg' attribute.
+  CCIfInReg<CCAssignToReg<[X15]>>,
+
+  CCDelegateTo<CC_AArch64_DarwinPCS>
+]>;
+
+let Entry = 1 in
+def CC_AArch64_Mono_AAPCS : CallingConv<[
+
+  // Mono marks the parameter it wants to pass in this non-abi register with
+  // the 'inreg' attribute.
+  CCIfInReg<CCAssignToReg<[X15]>>,
+
+  CCDelegateTo<CC_AArch64_AAPCS>
+]>;
+

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -6237,6 +6237,13 @@ CCAssignFn *AArch64TargetLowering::CCAssignFnForCall(CallingConv::ID CC,
    case CallingConv::AArch64_SME_ABI_Support_Routines_PreserveMost_From_X0:
    case CallingConv::AArch64_SME_ABI_Support_Routines_PreserveMost_From_X2:
      return CC_AArch64_AAPCS;
+  case CallingConv::Mono:
+    if (Subtarget->isTargetDarwin())
+	  return CC_AArch64_Mono_DarwinPCS;
+    else if (Subtarget->isTargetWindows())
+      report_fatal_error("Unsupported calling convention.");
+    else
+      return CC_AArch64_Mono_AAPCS;
   }
 }
 

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -390,6 +390,9 @@ AArch64RegisterInfo::getStrictlyReservedRegs(const MachineFunction &MF) const {
   markSuperRegs(Reserved, AArch64::WSP);
   markSuperRegs(Reserved, AArch64::WZR);
 
+  if (MF.getFunction().getCallingConv() == CallingConv::Mono)
+    markSuperRegs(Reserved, AArch64::W15);
+
   if (TFI->hasFP(MF) || TT.isOSDarwin())
     markSuperRegs(Reserved, AArch64::W29);
 

--- a/llvm/lib/Target/ARM/ARMBaseRegisterInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseRegisterInfo.cpp
@@ -214,6 +214,11 @@ getReservedRegs(const MachineFunction &MF) const {
   // Some targets reserve R9.
   if (STI.isR9Reserved())
     markSuperRegs(Reserved, ARM::R9);
+  if (MF.getFunction().getCallingConv() == CallingConv::Mono)
+    // FIXME: This is required for some reason, otherwise llvm treats R8 as a callee-saved registers
+    // even if we exclude it in getCalleeSavedRegs (). Luckily, R8 can still be used for argument
+    // passing even if it is 'reserved'.
+    markSuperRegs(Reserved, ARM::R8);
   // Reserve D16-D31 if the subtarget doesn't support them.
   if (!STI.hasD32()) {
     static_assert(ARM::D31 == ARM::D16 + 15, "Register list not consecutive!");

--- a/llvm/lib/Target/ARM/ARMCallingConv.h
+++ b/llvm/lib/Target/ARM/ARMCallingConv.h
@@ -47,7 +47,12 @@ bool RetCC_ARM_APCS(unsigned ValNo, MVT ValVT, MVT LocVT,
 bool RetFastCC_ARM_APCS(unsigned ValNo, MVT ValVT, MVT LocVT,
                         CCValAssign::LocInfo LocInfo, ISD::ArgFlagsTy ArgFlags,
                         CCState &State);
-
+bool CC_ARM_Mono_AAPCS(unsigned ValNo, MVT ValVT, MVT LocVT,
+                  CCValAssign::LocInfo LocInfo, ISD::ArgFlagsTy ArgFlags,
+                  CCState &State);
+bool CC_ARM_Mono_APCS(unsigned ValNo, MVT ValVT, MVT LocVT,
+                 CCValAssign::LocInfo LocInfo, ISD::ArgFlagsTy ArgFlags,
+                 CCState &State);
 } // namespace llvm
 
 #endif

--- a/llvm/lib/Target/ARM/ARMCallingConv.td
+++ b/llvm/lib/Target/ARM/ARMCallingConv.td
@@ -365,4 +365,25 @@ def CSR_GenericInt : CalleeSavedRegs<(add LR, (sequence "R%u", 12, 0))>;
 // registers.
 def CSR_FIQ : CalleeSavedRegs<(add LR, R11, (sequence "R%u", 7, 0))>;
 
+//===----------------------------------------------------------------------===//
+// ARM Mono calling conventions
+//===----------------------------------------------------------------------===//
+
+let Entry = 1 in
+def CC_ARM_Mono_APCS : CallingConv<[
+  // Mono marks the parameter it wants to pass in this non-abi register with
+  // the 'inreg' attribute.
+  CCIfInReg<CCAssignToReg<[R8]>>,
+
+  CCDelegateTo<CC_ARM_APCS>
+]>;
+
+let Entry = 1 in
+def CC_ARM_Mono_AAPCS : CallingConv<[
+  // Mono marks the parameter it wants to pass in this non-abi register with
+  // the 'inreg' attribute.
+  CCIfInReg<CCAssignToReg<[R8]>>,
+
+  CCDelegateTo<CC_ARM_AAPCS>
+]>;
 

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -2098,6 +2098,8 @@ ARMTargetLowering::getEffectiveCallingConv(CallingConv::ID CC,
       return CallingConv::ARM_AAPCS_VFP;
     else
       return CallingConv::ARM_AAPCS;
+  case CallingConv::Mono:
+	  return CallingConv::Mono;
   }
 }
 
@@ -2133,6 +2135,15 @@ CCAssignFn *ARMTargetLowering::CCAssignFnForNode(CallingConv::ID CC,
     return (Return ? RetCC_ARM_AAPCS : CC_ARM_AAPCS);
   case CallingConv::CFGuard_Check:
     return (Return ? RetCC_ARM_AAPCS : CC_ARM_Win32_CFGuard_Check);
+  case CallingConv::Mono:
+    if (Return) {
+      return CCAssignFnForNode(CallingConv::C, true, isVarArg);
+    } else {
+      if (Subtarget->isAAPCS_ABI())
+        return CC_ARM_Mono_AAPCS;
+      else
+        return CC_ARM_Mono_APCS;
+    }
   }
 }
 

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -1073,6 +1073,12 @@ def CC_Intel_OCL_BI : CallingConv<[
   CCDelegateTo<CC_X86_32_C>
 ]>;
 
+def CC_X86_32_Mono : CallingConv<[
+  CCIfInReg<CCAssignToReg<[EDX]>>,
+
+  CCDelegateTo<CC_X86_32_C>
+]>;
+
 //===----------------------------------------------------------------------===//
 // X86 Root Argument Calling Conventions
 //===----------------------------------------------------------------------===//
@@ -1092,6 +1098,7 @@ def CC_X86_32 : CallingConv<[
   CCIfCC<"CallingConv::GHC", CCDelegateTo<CC_X86_32_GHC>>,
   CCIfCC<"CallingConv::HiPE", CCDelegateTo<CC_X86_32_HiPE>>,
   CCIfCC<"CallingConv::X86_RegCall", CCDelegateTo<CC_X86_32_RegCall>>,
+  CCIfCC<"CallingConv::Mono", CCDelegateTo<CC_X86_32_Mono>>,
 
   // Otherwise, drop to normal X86-32 CC
   CCDelegateTo<CC_X86_32_C>
@@ -1112,6 +1119,7 @@ def CC_X86_64 : CallingConv<[
     CCIfSubtarget<"isTargetWin64()", CCDelegateTo<CC_X86_Win64_RegCall>>>,
   CCIfCC<"CallingConv::X86_RegCall", CCDelegateTo<CC_X86_SysV64_RegCall>>,
   CCIfCC<"CallingConv::X86_INTR", CCCustom<"CC_X86_Intr">>,
+  CCIfCC<"CallingConv::Mono", CCDelegateTo<CC_X86_64_Mono>>,
 
   // Mingw64 and native Win64 use Win64 CC
   CCIfSubtarget<"isTargetWin64()", CCDelegateTo<CC_X86_Win64_C>>,

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -761,6 +761,15 @@ def CC_X86_64_AnyReg : CallingConv<[
   CCCustom<"CC_X86_AnyReg_Error">
 ]>;
 
+def CC_X86_64_Mono : CallingConv<[
+  CCIfInReg<CCAssignToReg<[R10]>>,
+
+  // Mingw64 and native Win64 use Win64 CC
+  CCIfSubtarget<"isTargetWin64()", CCDelegateTo<CC_X86_Win64_C>>,
+  // Otherwise, drop to normal X86-64 CC
+  CCDelegateTo<CC_X86_64_C>
+]>;
+
 //===----------------------------------------------------------------------===//
 // X86 C Calling Convention
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/X86/X86FastISel.cpp
+++ b/llvm/lib/Target/X86/X86FastISel.cpp
@@ -1173,6 +1173,9 @@ bool X86FastISel::X86SelectRet(const Instruction *I) {
     return false;
 
   CallingConv::ID CC = F.getCallingConv();
+  if (CC == CallingConv::Mono && Subtarget->isTargetWin64())
+    CC = CallingConv::Win64;
+
   if (CC != CallingConv::C &&
       CC != CallingConv::Fast &&
       CC != CallingConv::Tail &&
@@ -3187,6 +3190,9 @@ bool X86FastISel::fastLowerCall(CallLoweringInfo &CLI) {
   // Functions using thunks for indirect calls need to use SDISel.
   if (Subtarget->useIndirectThunkCalls())
     return false;
+
+  if (CC == CallingConv::Mono && Subtarget->isTargetWin64())
+    CC = CallingConv::Win64;
 
   // Handle only C, fastcc, and webkit_js calling conventions for now.
   switch (CC) {

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -1498,7 +1498,10 @@ void X86FrameLowering::emitPrologue(MachineFunction &MF,
   bool NeedsWinFPO =
       !IsFunclet && STI.isTargetWin32() && MMI.getModule()->getCodeViewFlag();
   bool NeedsWinCFI = NeedsWin64CFI || NeedsWinFPO;
-  bool NeedsDwarfCFI = needsDwarfCFI(MF);
+  bool NeedsDwarfCFI =
+      Fn.getCallingConv() == CallingConv::Mono
+          ? MF.needsFrameMoves()
+          : needsDwarfCFI(MF);
   Register FramePtr = TRI->getFrameRegister(MF);
   const Register MachineFramePtr =
       STI.isTarget64BitILP32()

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -3674,7 +3674,9 @@ static bool canGuaranteeTCO(CallingConv::ID CC) {
 }
 
 /// Return true if we might ever do TCO for calls with this calling convention.
-static bool mayTailCallThisCC(CallingConv::ID CC) {
+static bool mayTailCallThisCC(CallingConv::ID CC, bool isTargetWin64) {
+  if (CC == CallingConv::Mono && isTargetWin64)
+    CC = CallingConv::Win64;
   switch (CC) {
   // C calling conventions:
   case CallingConv::C:
@@ -3705,7 +3707,7 @@ bool X86TargetLowering::mayBeEmittedAsTailCall(const CallInst *CI) const {
     return false;
 
   CallingConv::ID CalleeCC = CI->getCallingConv();
-  if (!mayTailCallThisCC(CalleeCC))
+  if (!mayTailCallThisCC(CalleeCC, Subtarget.isTargetWin64()))
     return false;
 
   return true;
@@ -5125,7 +5127,7 @@ bool X86TargetLowering::IsEligibleForTailCallOptimization(
     bool isVarArg, Type *RetTy, const SmallVectorImpl<ISD::OutputArg> &Outs,
     const SmallVectorImpl<SDValue> &OutVals,
     const SmallVectorImpl<ISD::InputArg> &Ins, SelectionDAG &DAG) const {
-  if (!mayTailCallThisCC(CalleeCC))
+  if (!mayTailCallThisCC(CalleeCC, Subtarget.isTargetWin64()))
     return false;
 
   // If -tailcallopt is specified, make fastcc functions tail-callable.

--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -297,6 +297,9 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
   if (MF->getFunction().hasFnAttribute("no_callee_saved_registers"))
     return CSR_NoRegs_SaveList;
 
+  if (CC == CallingConv::Mono && IsWin64)
+    CC = CallingConv::Win64;
+
   switch (CC) {
   case CallingConv::GHC:
   case CallingConv::HiPE:
@@ -419,6 +422,9 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
   bool HasSSE = Subtarget.hasSSE1();
   bool HasAVX = Subtarget.hasAVX();
   bool HasAVX512 = Subtarget.hasAVX512();
+
+  if ( CC == CallingConv::Mono && IsWin64)
+    CC = CallingConv::Win64;
 
   switch (CC) {
   case CallingConv::GHC:

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -347,6 +347,7 @@ public:
     case CallingConv::X86_ThisCall:
     case CallingConv::X86_VectorCall:
     case CallingConv::Intel_OCL_BI:
+    case CallingConv::Mono:
       return isTargetWin64();
     // This convention allows using the Win64 convention on other targets.
     case CallingConv::Win64:

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -4772,15 +4772,22 @@ struct VarArgAMD64Helper : public VarArgHelper {
     // nonzero shadow.
   }
 
+  bool isTargetWin64() const {
+    Triple TargetTriple(F.getParent()->getTargetTriple());
+    return TargetTriple.isArch64Bit() && TargetTriple.isOSWindows();
+  }
+
   void visitVAStartInst(VAStartInst &I) override {
-    if (F.getCallingConv() == CallingConv::Win64)
+    if (F.getCallingConv() == CallingConv::Win64 ||
+        (F.getCallingConv() == CallingConv::Mono && isTargetWin64()))
       return;
     VAStartInstrumentationList.push_back(&I);
     unpoisonVAListTagForInst(I);
   }
 
   void visitVACopyInst(VACopyInst &I) override {
-    if (F.getCallingConv() == CallingConv::Win64)
+    if (F.getCallingConv() == CallingConv::Win64 ||
+        (F.getCallingConv() == CallingConv::Mono && isTargetWin64()))
       return;
     unpoisonVAListTagForInst(I);
   }


### PR DESCRIPTION
These tables can be used to map a mono method index to its associated EH and unwind info.

(cherry picked from commit 3b5d2380563fef452c649b4dacf3eb1b66b0bc8b)