### PR TITLE
TLS support for linux-arm64

### DIFF
--- a/llvm/tools/objwriter/objwriter.cpp
+++ b/llvm/tools/objwriter/objwriter.cpp
@@ -473,6 +473,49 @@ int ObjectWriter::EmitSymbolRef(const char *SymbolName,
     Kind = MCSymbolRefExpr::VK_TPOFF;
     Size = 4;
     break;
+
+  case RelocType::IMAGE_REL_AARCH64_TLSLE_ADD_TPREL_HI12: {
+    const MCExpr* TargetExpr = GenTargetExpr(Symbol, Kind, Delta);
+    TargetExpr =
+      AArch64MCExpr::create(TargetExpr, AArch64MCExpr::VK_TPREL_HI12, *OutContext);
+    EmitRelocDirective(GetDFSize(), "R_AARCH64_TLSLE_ADD_TPREL_HI12", TargetExpr);
+    return 4;
+  }
+  case RelocType::IMAGE_REL_AARCH64_TLSLE_ADD_TPREL_LO12_NC: {
+    const MCExpr* TargetExpr = GenTargetExpr(Symbol, Kind, Delta);
+    TargetExpr =
+      AArch64MCExpr::create(TargetExpr, AArch64MCExpr::VK_TPREL_LO12_NC, *OutContext);
+    EmitRelocDirective(GetDFSize(), "R_AARCH64_TLSLE_ADD_TPREL_LO12_NC", TargetExpr);
+    return 4;
+  }
+
+  case RelocType::IMAGE_REL_AARCH64_TLSDESC_ADR_PAGE21: {
+    const MCExpr* TargetExpr = GenTargetExpr(Symbol, Kind, Delta);
+    TargetExpr =
+      AArch64MCExpr::create(TargetExpr, AArch64MCExpr::VK_TLSDESC_PAGE, *OutContext);
+    EmitRelocDirective(GetDFSize(), "R_AARCH64_TLSDESC_ADR_PAGE21", TargetExpr);
+    return 4;
+  }
+  case RelocType::IMAGE_REL_AARCH64_TLSDESC_LD64_LO12: {
+    const MCExpr* TargetExpr = GenTargetExpr(Symbol, Kind, Delta);
+    TargetExpr =
+      AArch64MCExpr::create(TargetExpr, AArch64MCExpr::VK_TLSDESC_LO12, *OutContext);
+    EmitRelocDirective(GetDFSize(), "R_AARCH64_TLSDESC_LD64_LO12", TargetExpr);
+    return 4;
+  }
+  case RelocType::IMAGE_REL_AARCH64_TLSDESC_ADD_LO12: {
+    const MCExpr* TargetExpr = GenTargetExpr(Symbol, Kind, Delta);
+    TargetExpr =
+      AArch64MCExpr::create(TargetExpr, AArch64MCExpr::VK_TLSDESC_LO12, *OutContext);
+    EmitRelocDirective(GetDFSize(), "R_AARCH64_TLSDESC_ADD_LO12", TargetExpr);
+    return 4;
+  }
+  case RelocType::IMAGE_REL_AARCH64_TLSDESC_CALL: {
+    const MCExpr* TargetExpr = GenTargetExpr(Symbol, Kind, Delta);
+    EmitRelocDirective(GetDFSize(), "R_AARCH64_TLSDESC_CALL", TargetExpr);
+    return 4;
+  }
+
   case RelocType::IMAGE_REL_BASED_REL32:
     if (OutContext->getObjectFileType() == MCContext::IsMachO &&
         OutContext->getTargetTriple().getArch() == Triple::aarch64) {

--- a/llvm/tools/objwriter/objwriter.h
+++ b/llvm/tools/objwriter/objwriter.h
@@ -59,9 +59,29 @@ enum class RelocType {
   IMAGE_REL_BASED_RELPTR32 = 0x7C,
   IMAGE_REL_BASED_ARM64_PAGEBASE_REL21 = 0x81,
   IMAGE_REL_BASED_ARM64_PAGEOFFSET_12A = 0x82,
+
+  //
+  // Relocation operators related to TLS access
+  //
+
+  // Windows x64
   IMAGE_REL_SECREL = 0x104,
+
+  // Linux x64
+  // GD model
   IMAGE_REL_TLSGD = 0x105,
+  // LE model
   IMAGE_REL_TPOFF = 0x106,
+
+  // Linux arm64
+  //    TLSDESC  (dynamic)
+  IMAGE_REL_AARCH64_TLSDESC_ADR_PAGE21 = 0x107,
+  IMAGE_REL_AARCH64_TLSDESC_LD64_LO12 = 0x108,
+  IMAGE_REL_AARCH64_TLSDESC_ADD_LO12 = 0x109,
+  IMAGE_REL_AARCH64_TLSDESC_CALL = 0x10A,
+  //    LE model 
+  IMAGE_REL_AARCH64_TLSLE_ADD_TPREL_HI12 = 0x10B,
+  IMAGE_REL_AARCH64_TLSLE_ADD_TPREL_LO12_NC = 0x10C,
 };
 
 enum class SymbolRefFlags


### PR DESCRIPTION
This is similar to https://github.com/dotnet/llvm-project/pull/429, just a different set of platform-specific relocation operators.
These are for linux-arm64