### PR TITLE
Fix a crash in the ImplicitNullChecks pass.

### DIFF
--- a/llvm/lib/CodeGen/ImplicitNullChecks.cpp
+++ b/llvm/lib/CodeGen/ImplicitNullChecks.cpp
@@ -351,6 +351,8 @@ ImplicitNullChecks::areMemoryOpsAliased(const MachineInstr &MI,
           return AR_MayAlias;
         continue;
       }
+      if (MMO2->getValue() == nullptr)
+		return AR_MayAlias;
       if (!AA->isNoAlias(
               MemoryLocation::getAfter(MMO1->getValue(), MMO1->getAAInfo()),
               MemoryLocation::getAfter(MMO2->getValue(), MMO2->getAAInfo())))


### PR DESCRIPTION
Re: https://github.com/dotnet/runtime/pull/46817#issuecomment-760542379 (cherry picked from commit f1f846f3c45025c765f29420858ecaa1738c004f)