### PR TITLE
Deduplicate `#include`

### DIFF
--- a/llvm/tools/objwriter/debugInfo/dwarf/dwarfGen.cpp
+++ b/llvm/tools/objwriter/debugInfo/dwarf/dwarfGen.cpp
@@ -12,7 +12,6 @@
 
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCContext.h"
-#include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCSectionMachO.h"
 #include "llvm/MC/MCAsmInfo.h"


### PR DESCRIPTION
As I was looking at the diff from the LLVM update in https://github.com/dotnet/runtime/pull/89299#issuecomment-1655133249, I noticed there was a race between @akoeplinger and @agocke to fix the build break and we ended up with two fixes.