### PR TITLE
[dotnet/release/8.0] [ObjWriter] Emit the MH_SUBSECTIONS_VIA_SYMBOLS header flag for Mach-O

### DIFF
--- a/llvm/tools/objwriter/objwriter.cpp
+++ b/llvm/tools/objwriter/objwriter.cpp
@@ -155,6 +155,10 @@ bool ObjectWriter::Init(llvm::StringRef ObjectFilePath, const char* tripleName) 
 
   CFIsPerOffset.truncate(0);
 
+  if (OutContext->getObjectFileType() == MCContext::IsMachO) {
+    Streamer->emitAssemblerFlag(MCAF_SubsectionsViaSymbols);
+  }
+
   return true;
 }
 


### PR DESCRIPTION

The flag tells the linker that there are no functions with overlapping code and thus the code sections can be divided into subsections based on the symbols. This is similar in effect to how `-ffunction-sections` behaves on ELF.

Notably, this enables optimization such as dead code stripping and identical code folding, if requested through linker switches.

Old ld64 linker tends to run into deep stack loop without this switch if `-dead_strip` is used (encountered in Xamarin, not used by regular NativeAOT), and often ends up stack overflowing. New Xcode 15+ linker completely fails to produce correct unwind tables without this flag, which results in the NativeAOT executables crashing during GC or on first stack walk.