### PR TITLE
Revert objwriter-related llvm changes

### DIFF
--- a/llvm/include/llvm/MC/MCObjectStreamer.h
+++ b/llvm/include/llvm/MC/MCObjectStreamer.h
@@ -138,11 +138,6 @@ public:
                                  const MCExpr *Value) override;
   void emitValueImpl(const MCExpr *Value, unsigned Size,
                      SMLoc Loc = SMLoc()) override;
-  /// \brief EmitValueImpl with additional param, that allows to emit PCRelative
-  /// MCFixup.
-  void emitValueImpl(const MCExpr *Value, unsigned Size, SMLoc Loc,
-                     bool isPCRelative);
-
   void emitULEB128Value(const MCExpr *Value) override;
   void emitSLEB128Value(const MCExpr *Value) override;
   void emitWeakReference(MCSymbol *Alias, const MCSymbol *Symbol) override;

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -149,7 +149,6 @@ public:
   virtual void emitPad(int64_t Offset);
   virtual void emitRegSave(const SmallVectorImpl<unsigned> &RegList,
                            bool isVector);
-  virtual void emitLsda(const MCSymbol *Symbol);
   virtual void emitUnwindRaw(int64_t StackOffset,
                              const SmallVectorImpl<uint8_t> &Opcodes);
 
@@ -708,9 +707,6 @@ public:
   /// This is used to implement assembler directives such as .byte, .ascii,
   /// etc.
   virtual void emitBytes(StringRef Data);
-
-  /// \brief Emit the given \p Instruction data into the current section.
-  virtual void emitInstructionBytes(StringRef Data);
 
   /// Functionally identical to EmitBytes. When emitting textual assembly, this
   /// method uses .byte directives instead of .ascii or .asciz for readability.

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -244,7 +244,7 @@ void MCObjectStreamer::emitCFISections(bool EH, bool Debug) {
 }
 
 void MCObjectStreamer::emitValueImpl(const MCExpr *Value, unsigned Size,
-                                     SMLoc Loc, bool isPCRelative) {
+                                     SMLoc Loc) {
   MCStreamer::emitValueImpl(Value, Size, Loc);
   MCDataFragment *DF = getOrCreateDataFragment();
   flushPendingLabels(DF, DF->getContents().size());
@@ -264,13 +264,8 @@ void MCObjectStreamer::emitValueImpl(const MCExpr *Value, unsigned Size,
   }
   DF->getFixups().push_back(
       MCFixup::create(DF->getContents().size(), Value,
-                      MCFixup::getKindForSize(Size, isPCRelative), Loc));
+                      MCFixup::getKindForSize(Size, false), Loc));
   DF->getContents().resize(DF->getContents().size() + Size, 0);
-}
-
-void MCObjectStreamer::emitValueImpl(const MCExpr *Value, unsigned Size,
-                                     SMLoc Loc) {
-  emitValueImpl(Value, Size, Loc, false);
 }
 
 MCSymbol *MCObjectStreamer::emitCFILabel() {

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -1221,7 +1221,6 @@ void MCStreamer::emitTBSSSymbol(MCSection *Section, MCSymbol *Symbol,
 void MCStreamer::changeSection(MCSection *, const MCExpr *) {}
 void MCStreamer::emitWeakReference(MCSymbol *Alias, const MCSymbol *Symbol) {}
 void MCStreamer::emitBytes(StringRef Data) {}
-void MCStreamer::emitInstructionBytes(StringRef Data) { emitBytes(Data); }
 void MCStreamer::emitBinaryData(StringRef Data) { emitBytes(Data); }
 void MCStreamer::emitValueImpl(const MCExpr *Value, unsigned Size, SMLoc Loc) {
   visitUsedExpr(*Value);

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
@@ -134,7 +134,6 @@ static unsigned getFixupKindNumBytes(unsigned Kind) {
   case AArch64::fixup_aarch64_pcrel_call26:
   case FK_Data_4:
   case FK_SecRel_4:
-  case FK_PCRel_4:
     return 4;
 
   case FK_Data_8:
@@ -327,20 +326,14 @@ static uint64_t adjustFixupValue(const MCFixup &Fixup, const MCValue &Target,
   case FK_Data_8:
   case FK_SecRel_2:
   case FK_SecRel_4:
-  case FK_PCRel_4:
     return Value;
   }
 }
 
 std::optional<MCFixupKind>
 AArch64AsmBackend::getFixupKind(StringRef Name) const {
-  if (!TheTriple.isOSBinFormatELF()) {
-    return StringSwitch<std::optional<MCFixupKind>>(Name)
-      .Case("R_AARCH64_CALL26", (MCFixupKind)AArch64::fixup_aarch64_pcrel_call26)
-      .Case("R_AARCH64_ADR_PREL_PG_HI21", (MCFixupKind)AArch64::fixup_aarch64_pcrel_adrp_imm21)
-      .Case("R_AARCH64_ADD_ABS_LO12_NC", (MCFixupKind)AArch64::fixup_aarch64_add_imm12)
-      .Default(MCAsmBackend::getFixupKind(Name));
-  }
+  if (!TheTriple.isOSBinFormatELF())
+    return std::nullopt;
 
   unsigned Type = llvm::StringSwitch<unsigned>(Name)
 #define ELF_RELOC(X, Y)  .Case(#X, Y)

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
@@ -132,7 +132,6 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
       return ELF::R_AARCH64_NONE;
     case FK_Data_2:
       return R_CLS(PREL16);
-    case FK_PCRel_4:
     case FK_Data_4: {
       return Target.getAccessVariant() == MCSymbolRefExpr::VK_PLT
                  ? R_CLS(PLT32)

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -455,8 +455,6 @@ unsigned ARMAsmBackend::adjustFixupValue(const MCAssembler &Asm,
   case FK_Data_2:
   case FK_Data_4:
     return Value;
-  case FK_PCRel_4:
-    return Value;
   case FK_SecRel_2:
     return Value;
   case FK_SecRel_4:
@@ -977,9 +975,6 @@ static unsigned getFixupKindNumBytes(unsigned Kind) {
   case ARM::fixup_bfcsel_else_target:
   case ARM::fixup_wls:
   case ARM::fixup_le:
-    return 4;
-
-  case FK_PCRel_4:
     return 4;
 
   case FK_SecRel_2:

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
@@ -111,8 +111,6 @@ unsigned ARMELFObjectWriter::GetRelocTypeInner(const MCValue &Target,
       case MCSymbolRefExpr::VK_ARM_PREL31:
         return ELF::R_ARM_PREL31;
       }
-    case FK_PCRel_4:
-      return ELF::R_ARM_REL32;
     case ARM::fixup_arm_blx:
     case ARM::fixup_arm_uncondbl:
       switch (Modifier) {

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
@@ -83,7 +83,6 @@ class ARMTargetAsmStreamer : public ARMTargetStreamer {
   void emitPad(int64_t Offset) override;
   void emitRegSave(const SmallVectorImpl<unsigned> &RegList,
                    bool isVector) override;
-  void emitLsda(const MCSymbol* Symbol) override;
   void emitUnwindRaw(int64_t Offset,
                      const SmallVectorImpl<uint8_t> &Opcodes) override;
 
@@ -381,8 +380,6 @@ void ARMTargetAsmStreamer::emitARMWinCFICustom(unsigned Opcode) {
   OS << "\n";
 }
 
-void ARMTargetAsmStreamer::emitLsda(const MCSymbol* Symbol) {}
-
 class ARMTargetELFStreamer : public ARMTargetStreamer {
 private:
   StringRef CurrentVendor;
@@ -408,7 +405,6 @@ private:
   void emitPad(int64_t Offset) override;
   void emitRegSave(const SmallVectorImpl<unsigned> &RegList,
                    bool isVector) override;
-  void emitLsda(const MCSymbol *Symbol) override;
   void emitUnwindRaw(int64_t Offset,
                      const SmallVectorImpl<uint8_t> &Opcodes) override;
 
@@ -476,7 +472,6 @@ public:
   void emitMovSP(unsigned Reg, int64_t Offset = 0);
   void emitPad(int64_t Offset);
   void emitRegSave(const SmallVectorImpl<unsigned> &RegList, bool isVector);
-  void emitLsda(const MCSymbol* Symbol);
   void emitUnwindRaw(int64_t Offset, const SmallVectorImpl<uint8_t> &Opcodes);
   void emitFill(const MCExpr &NumBytes, uint64_t FillValue,
                 SMLoc Loc) override {
@@ -553,18 +548,6 @@ public:
   /// necessary.
   void emitBytes(StringRef Data) override {
     emitDataMappingSymbol();
-    MCELFStreamer::emitBytes(Data);
-  }
-
-  /// This function is the one used to emit instruction data into the ELF
-  /// streamer. We override it to add the appropriate mapping symbol if
-  /// necessary.
-  void emitInstructionBytes(StringRef Data) override {
-    if (IsThumb)
-      EmitThumbMappingSymbol();
-    else
-      EmitARMMappingSymbol();
-
     MCELFStreamer::emitBytes(Data);
   }
 
@@ -753,7 +736,6 @@ private:
   bool CantUnwind;
   SmallVector<uint8_t, 64> Opcodes;
   UnwindOpcodeAssembler UnwindOpAsm;
-  const MCSymbol *Lsda;
 };
 
 } // end anonymous namespace
@@ -794,10 +776,6 @@ void ARMTargetELFStreamer::emitPad(int64_t Offset) {
 void ARMTargetELFStreamer::emitRegSave(const SmallVectorImpl<unsigned> &RegList,
                                        bool isVector) {
   getStreamer().emitRegSave(RegList, isVector);
-}
-
-void ARMTargetELFStreamer::emitLsda(const MCSymbol *Symbol) {
-  getStreamer().emitLsda(Symbol);
 }
 
 void ARMTargetELFStreamer::emitUnwindRaw(int64_t Offset,
@@ -1222,7 +1200,6 @@ void ARMELFStreamer::EHReset() {
   PendingOffset = 0;
   UsedFP = false;
   CantUnwind = false;
-  Lsda = nullptr;
 
   Opcodes.clear();
   UnwindOpAsm.Reset();
@@ -1325,8 +1302,6 @@ void ARMELFStreamer::FlushUnwindOpcodes(bool NoHandlerData) {
   }
 
   // Finalize the unwind opcode sequence
-  if (Lsda != nullptr && Opcodes.size() <= 4u)
-    PersonalityIndex = ARM::EHABI::AEABI_UNWIND_CPP_PR1;
   UnwindOpAsm.Finalize(PersonalityIndex, Opcodes);
 
   // For compact model 0, we have to emit the unwind opcodes in the .ARM.exidx
@@ -1371,13 +1346,7 @@ void ARMELFStreamer::FlushUnwindOpcodes(bool NoHandlerData) {
   //
   // In case that the .handlerdata directive is not specified by the
   // programmer, we should emit zero to terminate the handler data.
-  if (Lsda != nullptr) {
-    const MCSymbolRefExpr *LsdaRef =
-      MCSymbolRefExpr::create(Lsda,
-                              MCSymbolRefExpr::VK_None,
-                              getContext());
-    emitValue(LsdaRef, 4);
-  } else if (NoHandlerData && !Personality)
+  if (NoHandlerData && !Personality)
     emitInt32(0);
 }
 
@@ -1489,10 +1458,6 @@ void ARMELFStreamer::emitRegSave(const SmallVectorImpl<unsigned> &RegList,
       UnwindOpAsm.EmitRegSave(0);
     }
   }
-}
-
-void ARMELFStreamer::emitLsda(const MCSymbol *Symbol) {
-  Lsda = Symbol;
 }
 
 void ARMELFStreamer::emitUnwindRaw(int64_t Offset,

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMTargetStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMTargetStreamer.cpp
@@ -99,7 +99,6 @@ void ARMTargetStreamer::emitMovSP(unsigned Reg, int64_t Offset) {}
 void ARMTargetStreamer::emitPad(int64_t Offset) {}
 void ARMTargetStreamer::emitRegSave(const SmallVectorImpl<unsigned> &RegList,
                                     bool isVector) {}
-void ARMTargetStreamer::emitLsda(const MCSymbol *Symbol) {}
 void ARMTargetStreamer::emitUnwindRaw(int64_t StackOffset,
                                       const SmallVectorImpl<uint8_t> &Opcodes) {
 }


### PR DESCRIPTION
This reverts commit 67f5503adc0fe9d886a33df58f49a4b3e2b8c21e.

Follow-up to https://github.com/dotnet/llvm-project/pull/527