### PR TITLE
Add CodeQL exclusions and CG manifest files

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -1,0 +1,9 @@
+path_classifiers:
+  library:
+    # Nearly all folders in this repo are library code that we do not run static analysis
+    # over. We'll exclude folders that we wholly own. We instead rely on CG and similar
+    # registration mechanisms to report issues to us.
+    - "**/*"
+    - exclude:
+      - "eng"
+      - "nuget"

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "version": 1,
+    "registrations": [
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/llvm/llvm-project",
+                    "commitHash": "3f43d803382d57e3fc010ca19833077d1023e9c9"
+                }
+            },
+            "developmentDependency": false
+        }
+    ]
+}


### PR DESCRIPTION
Similar to https://github.com/dotnet/llvm-project/pull/536, but targets the main-14.x branch. Makes TSA happy since it's still running regular builds over both the 16.x and 14.x branches.

/cc @akoeplinger 