### PR TITLE
Add missing shared library to the transport package

### DIFF
--- a/nuget/Microsoft.NETCore.Runtime.Wasm.LLVM.Transport/Linux.Microsoft.NETCore.Runtime.Wasm.LLVM.Transport.props
+++ b/nuget/Microsoft.NETCore.Runtime.Wasm.LLVM.Transport/Linux.Microsoft.NETCore.Runtime.Wasm.LLVM.Transport.props
@@ -36,5 +36,6 @@
     <File Include="$(_LLVMInstallDir)\lib\clang\$(LLVMVersionShort)\include\**" TargetPath="tools\$(PackageTargetRuntime)\lib\clang\$(LLVMVersionShort)\include\%(RecursiveDir)\" />
     <File Include="$(_LibCxxInstallDir)\lib\libc++.so.1" TargetPath="tools\$(PackageTargetRuntime)\lib\" />
     <File Include="$(_LibCxxInstallDir)\lib\libc++abi.so.1" TargetPath="tools\$(PackageTargetRuntime)\lib\" />
+    <File Include="$(_LibCxxInstallDir)\lib\libunwind.so.1" TargetPath="tools\$(PackageTargetRuntime)\lib\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
clang is missing libunwind

```
> ldd emsdk/llvm/9.0.0/bin/clang-19
        linux-vdso.so.1 (0x00007ffff3784000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f510469a000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f5104695000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f5104690000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f51045a5000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f5104589000)
        libc++.so.1 => /home/rodo/local/git/emsdk/llvm/9.0.0/bin/../lib/libc++.so.1 (0x00007f5104427000)
        libc++abi.so.1 => /home/rodo/local/git/emsdk/llvm/9.0.0/bin/../lib/libc++abi.so.1 (0x00007f51043d9000)
        libunwind.so.1 => not found
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f51043b9000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f51041ac000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f510adca000)
        libunwind.so.1 => not found
        libunwind.so.1 => not found
```