### PR TITLE
Remove LLVM_TOOLS_TO_BUILD option from llvm.proj

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -92,7 +92,6 @@
     <_LLVMBuildArgs Include='-DLLVM_BUILD_TESTS=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_BUILD_EXAMPLES=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_INCLUDE_EXAMPLES=OFF' />
-    <_LLVMBuildArgs Include='-DLLVM_TOOLS_TO_BUILD="llc%3Bllvm-addr2line%3Bllvm-ar%3Bllvm-as%3Bllvm-config%3Bllvm-cxxfilt%3Bllvm-dis%3Bllvm-dwarfdump%3Bllvm-dwp%3Bllvm-mc%3Bllvm-mca%3Bllvm-nm%3Bllvm-objcopy%3Bllvm-objdump%3Bllvm-ranlib%3Bllvm-readobj%3Bllvm-size%3Bllvm-strings%3Bllvm-strip%3Bllvm-symbolizer%3Bopt%3BFileCheck"' />
     <_LLVMBuildArgs Include='-DLLVM_INSTALL_BINUTILS_SYMLINKS=TRUE' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_LIBXML2=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_TERMINFO=OFF' />


### PR DESCRIPTION
This was a custom change added in https://github.com/dotnet/llvm-project/commit/da3d772d7a9b5972f5219036b74a37cfbaef04e8 but we missed porting that to recent branches.

Given we've not even noticed until now and it just causes building a bit more tools I'd argue it's better to just remove this.