### PR TITLE
Do not use unwinder in libc++ and clang

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -100,6 +100,7 @@
     <_LLVMBuildArgs Include='-DLLVM_EXTERNALIZE_DEBUGINFO=ON' />
     <_LLVMBuildArgs Include='-DLLVM_EXTERNALIZE_DEBUGINFO_INSTALL=ON' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_PDB=ON' />
+    <_LLVMBuildArgs Include='-DCOMPILER_RT_USE_LLVM_UNWINDER=OFF' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dbg' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dwarf -DLLVM_EXTERNALIZE_DEBUGINFO_FLATTEN=ON' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'FreeBSD'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dbg' />
@@ -171,6 +172,7 @@
       <_LibCxxBuildArgs Include='-DCMAKE_POSITION_INDEPENDENT_CODE=ON' />
       <_LibCxxBuildArgs Include="-DCMAKE_CXX_COMPILER_TARGET=$(ClangTarget)" />
       <_LibCxxBuildArgs Include="-DLLVM_DEFAULT_TARGET_TRIPLE=$(ClangTarget)" />
+      <_LibCxxBuildArgs Include="-DLIBCXXABI_USE_LLVM_UNWINDER=OFF" />
       <_LibCxxBuildArgs Condition="$(ClangTarget.ToLowerInvariant().Contains('musl'))" Include="-DLIBCXX_HAS_MUSL_LIBC=ON" />
     </ItemGroup>
     <PropertyGroup>


### PR DESCRIPTION
Tested on ubuntu

    LD_LIBRARY_PATH=./artifacts/obj/libcxx/InstallRoot-arm64/lib/ ldd ./artifacts/obj/InstallRoot-arm64/bin/clang++
    	linux-vdso.so.1 (0x0000ffffb9058000)
    	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffffb2ec0000)
    	libz.so.1 => /lib/aarch64-linux-gnu/libz.so.1 (0x0000ffffb2e80000)
    	libc++.so.1 => ./artifacts/obj/libcxx/InstallRoot-arm64/lib/libc++.so.1 (0x0000ffffb2cf0000)
    	libc++abi.so.1 => ./artifacts/obj/libcxx/InstallRoot-arm64/lib/libc++abi.so.1 (0x0000ffffb2c70000)
    	libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffffb2c30000)
    	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffb2a70000)
    	/lib/ld-linux-aarch64.so.1 (0x0000ffffb901b000)