### PR TITLE
Disable function specialization

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1108,11 +1108,12 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
   // and prior to optimizing globals.
   // FIXME: This position in the pipeline hasn't been carefully considered in
   // years, it should be re-analyzed.
-  MPM.addPass(IPSCCPPass(
-              IPSCCPOptions(/*AllowFuncSpec=*/
-                            Level != OptimizationLevel::Os &&
-                            Level != OptimizationLevel::Oz &&
-                            !isLTOPreLink(Phase))));
+  // mono: FIXME: disabled for now, we need to fix mono EH frame generation first
+  // MPM.addPass(IPSCCPPass(
+  //             IPSCCPOptions(/*AllowFuncSpec=*/
+  //                           Level != OptimizationLevel::Os &&
+  //                           Level != OptimizationLevel::Oz &&
+  //                           !isLTOPreLink(Phase))));
 
   // Attach metadata to indirect call sites indicating the set of functions
   // they may target at run-time. This should follow IPSCCP.
@@ -1761,9 +1762,11 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
     // Propagate constants at call sites into the functions they call.  This
     // opens opportunities for globalopt (and inlining) by substituting function
     // pointers passed as arguments to direct uses of functions.
-    MPM.addPass(IPSCCPPass(IPSCCPOptions(/*AllowFuncSpec=*/
-                                         Level != OptimizationLevel::Os &&
-                                         Level != OptimizationLevel::Oz)));
+
+    // mono: FIXME: disabled for now, we need to fix mono EH frame generation first
+    // MPM.addPass(IPSCCPPass(IPSCCPOptions(/*AllowFuncSpec=*/
+    //                                      Level != OptimizationLevel::Os &&
+    //                                      Level != OptimizationLevel::Oz)));
 
     // Attach metadata to indirect call sites indicating the set of functions
     // they may target at run-time. This should follow IPSCCP.


### PR DESCRIPTION
It breaks mono's AOT compiled code, because the specialized functions are outside of generated EH frame code range.

We can re-enable it, once we fix EH frame generation for mono.