### PR TITLE
Target macOS 12.0 as minimum

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -138,8 +138,7 @@
     <_LLVMBuildArgs Include='-DCMAKE_EXE_LINKER_FLAGS_INIT="$(_SharedLinkerFlags) $(_LibCxxLinkerFlags)"' />
     <_LLVMBuildArgs Include='-DCMAKE_SHARED_LINKER_FLAGS_INIT="$(_SharedLinkerFlags) $(_LibCxxLinkerFlags)"' />
     <_LLVMBuildArgs Include='-DCMAKE_MODULE_LINKER_FLAGS_INIT="$(_SharedLinkerFlags) $(_LibCxxLinkerFlags)"' />
-    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64'" Include='-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0' />
-    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX' and '$(TargetArchitecture)' == 'x64'" Include='-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX'" Include='-DCMAKE_OSX_DEPLOYMENT_TARGET=12.0' />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildOS)' == 'Windows_NT'">


### PR DESCRIPTION
Just a small thing I noticed while looking at the llvm.proj. Matches what we do for runtime in net9.0