### PR TITLE
Add nuget package for libclang and python bindings

### DIFF
--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/Directory.Build.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/Directory.Build.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="../Directory.Build.props" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.builds
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.builds
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.Build.Traversal">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(builds.targets))" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.pkgproj
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.pkgproj
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <Import Condition="'$(_packageTargetOSGroup)' != ''"  Project="$(MSBuildThisFileDirectory)runtime.$(_packageTargetOSGroup).$(MSBuildProjectName).props" />
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/runtime.FreeBSD.Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/runtime.FreeBSD.Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <File Include="$(ProjectDir)\clang\bindings\python\clang\**" TargetPath="tools\python-bindings" />
+    <File Include="$(_LLVMInstallDir)\lib\libclang.so" TargetPath="tools\libclang.so" />
+  </ItemGroup>
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/runtime.Linux.Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <File Include="$(ProjectDir)\clang\bindings\python\clang\**" TargetPath="tools\python-bindings" />
+    <File Include="$(_LLVMInstallDir)\lib\libclang.so" TargetPath="tools\libclang.so" />
+  </ItemGroup>
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/runtime.OSX.Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <File Include="$(ProjectDir)\clang\bindings\python\clang\**" TargetPath="tools\python-bindings" />
+    <File Include="$(_LLVMInstallDir)\lib\libclang.dylib" TargetPath="tools\libclang.dylib" />
+  </ItemGroup>
+</Project>

--- a/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.props
+++ b/nuget/Microsoft.NETCore.Runtime.Mono.LLVM.Libclang/runtime.Windows_NT.Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <File Include="$(ProjectDir)\clang\bindings\python\clang\**" TargetPath="tools\python-bindings" />
+    <File Include="$(_LLVMInstallDir)\bin\libclang.dll" TargetPath="tools\libclang.dll" />
+  </ItemGroup>
+</Project>

--- a/nuget/descriptions.json
+++ b/nuget/descriptions.json
@@ -10,6 +10,11 @@
         "CommonTypes": [ ]
     },
     {
+        "Name": "Microsoft.NETCore.Runtime.Mono.LLVM.Libclang",
+        "Description": "The libclang library and Python bindings.",
+        "CommonTypes": [ ]
+    },
+    {
         "Name": "Microsoft.NETCore.Runtime.Mono.LLVM.Sdk",
         "Description": "The .NET Core fork of the LLVM project, used to compile the Mono .NET Core runtime in LLVM JIT mode. Internal implementation package not meant for direct consumption.  Please do not reference directly.",
         "CommonTypes": [ ]

--- a/nuget/packages.builds
+++ b/nuget/packages.builds
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup Condition="'$(BuildJitToolsOnly)' != 'true'">
+    <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Libclang\Microsoft.NETCore.Runtime.Mono.LLVM.Libclang.builds" />
     <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Sdk\Microsoft.NETCore.Runtime.Mono.LLVM.Sdk.builds" />
     <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Tools\Microsoft.NETCore.Runtime.Mono.LLVM.Tools.builds" />
     <ProjectReference Condition="'$(Configuration)' == 'Release'" Include="Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.A.Transport\Microsoft.NETCore.Runtime.Mono.LLVM.Wasm.A.Transport.builds" />


### PR DESCRIPTION
This allows us to use our own llvm in the dotnet/runtime build for the offsets tool, instead of relying on the system clang.