### PR TITLE
[lld][WebAssembly] Ignore local symbols when parsing lazy object file…

### DIFF
--- a/lld/test/wasm/archive-local-sym.s
+++ b/lld/test/wasm/archive-local-sym.s
@@ -1,0 +1,24 @@
+## Test that local symbols in archive files are ignored.
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t/foo.o %t/foo.s
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t/main.o %t/main.s
+# RUN: rm -f %t/libfoo.a
+# RUN: llvm-ar rcs %t/libfoo.a %t/foo.o
+# RUN: not wasm-ld %t/libfoo.a %t/main.o -o out.wasm 2>&1 | FileCheck %s
+
+#--- main.s
+
+.functype foo () -> ()
+
+.globl _start
+_start:
+  .functype _start () -> ()
+  call foo
+# CHECK: main.o: undefined symbol: foo
+  end_function
+
+#--- foo.s
+
+foo:
+  .functype foo () -> ()
+  end_function

--- a/lld/wasm/InputFiles.cpp
+++ b/lld/wasm/InputFiles.cpp
@@ -392,7 +392,7 @@ void ObjFile::parseLazy() {
                     << wasmObj.get() << "\n");
   for (const SymbolRef &sym : wasmObj->symbols()) {
     const WasmSymbol &wasmSym = wasmObj->getWasmSymbol(sym.getRawDataRefImpl());
-    if (!wasmSym.isDefined())
+    if (wasmSym.isUndefined() || wasmSym.isBindingLocal())
       continue;
     symtab->addLazy(wasmSym.Info.Name, this);
     // addLazy() may trigger this->extract() if an existing symbol is an


### PR DESCRIPTION
Cherry pick linker fix from main: https://github.com/llvm/llvm-project/pull/104876

It will fix the runtime issue https://github.com/dotnet/runtime/issues/109289 for us