### PR TITLE
Add CMAKE_MODULE_LINKER_FLAGS_INIT for consistency with non-Windows build

### DIFF
--- a/llvm.proj
+++ b/llvm.proj
@@ -148,8 +148,9 @@
   <ItemGroup Condition="'$(BuildOS)' == 'Windows_NT'">
     <_LLVMBuildArgs Include='-DCMAKE_C_FLAGS="$(_CFlags) "' />
     <_LLVMBuildArgs Include='-DCMAKE_CXX_FLAGS="$(_CFlags) "' />
-    <_LLVMBuildArgs Include='-DCMAKE_SHARED_LINKER_FLAGS_INIT="$(_SharedLinkerFlags)" ' />
     <_LLVMBuildArgs Include='-DCMAKE_EXE_LINKER_FLAGS_INIT="$(_SharedLinkerFlags)" ' />
+    <_LLVMBuildArgs Include='-DCMAKE_SHARED_LINKER_FLAGS_INIT="$(_SharedLinkerFlags)" ' />
+    <_LLVMBuildArgs Include='-DCMAKE_MODULE_LINKER_FLAGS_INIT="$(_SharedLinkerFlags)" ' />
   </ItemGroup>
 
   <Target Name="_LLVMBeforeBuild">


### PR DESCRIPTION
Noticed in https://github.com/dotnet/llvm-project/pull/686
