### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -26,7 +26,6 @@ stages:
     parameters:
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
       enableSourceBuild: true
       sourceBuildParameters:
         platforms:

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -112,12 +112,13 @@ extends:
         parameters:
           enablePublishBuildArtifacts: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           jobs:
 
           ############ LINUX BUILD ############
           - ${{ each buildjob in parameters.linuxBuilds }}:
             - job: Build_${{ replace(buildjob.assetManifestOS, '-', '_') }}_${{ buildjob.arch }}
+              enablePublishing: true
               displayName: ${{ buildjob.assetManifestOS }} ${{ buildjob.arch }}
               timeoutInMinutes: 600
               variables:
@@ -154,6 +155,7 @@ extends:
           ############ MACOS BUILD ############
           - ${{ each buildjob in parameters.macBuilds }}:
             - job: Build_macOS_${{ buildjob.arch }}
+              enablePublishing: true
               displayName: macOS ${{ buildjob.arch }}
               timeoutInMinutes: 600
               variables:
@@ -187,6 +189,7 @@ extends:
           ############ WINDOWS BUILD ############
           - ${{ each buildjob in parameters.windowsBuilds }}:
             - job: Build_Windows_${{ buildjob.arch }}_${{ buildjob.BuildConfig }}
+              enablePublishing: true
               displayName: Windows ${{ buildjob.arch }} ${{ buildjob.BuildConfig }}
               timeoutInMinutes: 600
               variables:
@@ -224,6 +227,7 @@ extends:
     ############ POST BUILD ARCADE LOGIC ############
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
+        publishingInfraVersion: 4
         enableSourceLinkValidation: false
         enableSigningValidation: false
         enableSymbolValidation: false

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -22,6 +22,5 @@ variables:
     - group: DotNet-HelixApi-Access
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=true
         /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Related to dotnet/arcade#16697.

This updates the repo from Arcade V3 publishing to V4 by:
- setting PublishingVersion to 4
- switching pipeline jobs to V4 publishingVersion/enablePublishing
- removing legacy V3 publish toggles