### PR TITLE
[wasm] Bump LLVM to 23 with Mono patches

### DIFF
--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -41,7 +41,7 @@ stages:
             x64:
               assetManifestOS: linux
               assetManifestPlatform: x64
-              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64
               rootfs: /crossrootfs/x64
               ExtraArgs: -p:LibsRoot=/crossrootfs/x64/usr/lib/x86_64-linux-gnu
               ClangTargetArg: /p:ClangTarget=x86_64-linux-gnu

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -46,7 +46,7 @@ stages:
             x64:
               assetManifestOS: linux
               assetManifestPlatform: x64
-              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64
               rootfs: /crossrootfs/x64
               ExtraArgs: -p:LibsRoot=/crossrootfs/x64/usr/lib/x86_64-linux-gnu
               ClangTargetArg: /p:ClangTarget=x86_64-linux-gnu
@@ -55,7 +55,7 @@ stages:
             arm64:
               assetManifestOS: linux
               assetManifestPlatform: arm64
-              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64
               rootfs: /crossrootfs/arm64
               ExtraArgs: -p:LibsRoot=/crossrootfs/arm64/usr/lib/aarch64-linux-gnu
               ClangTargetArg: /p:ClangTarget=aarch64-linux-gnu
@@ -64,7 +64,7 @@ stages:
             arm:
               assetManifestOS: linux
               assetManifestPlatform: arm
-              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm
               rootfs: /crossrootfs/arm
               ExtraArgs: -p:LibsRoot=/crossrootfs/arm/usr/lib/arm-linux-gnueabihf
               ClangTargetArg: /p:ClangTarget=arm-linux-gnueabihf
@@ -99,7 +99,7 @@ stages:
             x64:
               assetManifestOS: linux-musl
               assetManifestPlatform: x64
-              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64-musl
               rootfs: /crossrootfs/x64
               ExtraArgs: -p:LibsRoot=/crossrootfs/x64/lib
               ClangTargetArg: /p:ClangTarget=x86_64-alpine-linux-musl
@@ -108,7 +108,7 @@ stages:
             arm64:
               assetManifestOS: linux-musl
               assetManifestPlatform: arm64
-              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine
+              imagename: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64-musl
               rootfs: /crossrootfs/arm64
               ExtraArgs: -p:LibsRoot=/crossrootfs/arm64/lib
               ClangTargetArg: /p:ClangTarget=aarch64-alpine-linux-musl

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -24,35 +24,35 @@ parameters:
   default:
   - arch: x64
     assetManifestOS: linux
-    imagename: mariner2crossamd64
+    imagename: azurelinux3crossamd64
     rootfs: /crossrootfs/x64
     ExtraArgs: -p:LibsRoot=/crossrootfs/x64/usr/lib/x86_64-linux-gnu
     ClangTargetArg: /p:ClangTarget=x86_64-linux-gnu
     ClangBinDirArg: /p:ClangBinDir=/usr/local/bin
   - arch: arm64
     assetManifestOS: linux
-    imagename: mariner2crossarm64
+    imagename: azurelinux3crossarm64
     rootfs: /crossrootfs/arm64
     ExtraArgs: -p:LibsRoot=/crossrootfs/arm64/usr/lib/aarch64-linux-gnu
     ClangTargetArg: /p:ClangTarget=aarch64-linux-gnu
     ClangBinDirArg: /p:ClangBinDir=/usr/local/bin
   - arch: arm
     assetManifestOS: linux
-    imagename: mariner2crossarm
+    imagename: azurelinux3crossarm
     rootfs: /crossrootfs/arm
     ExtraArgs: -p:LibsRoot=/crossrootfs/arm/usr/lib/arm-linux-gnueabihf
     ClangTargetArg: /p:ClangTarget=arm-linux-gnueabihf
     ClangBinDirArg: /p:ClangBinDir=/usr/local/bin
   - arch: x64
     assetManifestOS: linux-musl
-    imagename: mariner2crossamd64alpine
+    imagename: azurelinux3crossamd64musl
     rootfs: /crossrootfs/x64
     ExtraArgs: -p:LibsRoot=/crossrootfs/x64/lib -p:OutputRid=linux-musl-x64
     ClangTargetArg: /p:ClangTarget=x86_64-alpine-linux-musl
     ClangBinDirArg: /p:ClangBinDir=/usr/local/bin
   - arch: arm64
     assetManifestOS: linux-musl
-    imagename: mariner2crossarm64alpine
+    imagename: azurelinux3crossarm64musl
     rootfs: /crossrootfs/arm64
     ExtraArgs: -p:LibsRoot=/crossrootfs/arm64/lib -p:OutputRid=linux-musl-arm64
     ClangTargetArg: /p:ClangTarget=aarch64-alpine-linux-musl
@@ -94,16 +94,16 @@ extends:
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
     containers:
-      mariner2crossamd64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
-      mariner2crossarm64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64
-      mariner2crossarm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm
-      mariner2crossamd64alpine:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine
-      mariner2crossarm64alpine:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine
+      azurelinux3crossamd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64
+      azurelinux3crossarm64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64
+      azurelinux3crossarm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm
+      azurelinux3crossamd64musl:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64-musl
+      azurelinux3crossarm64musl:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64-musl
     stages:
     - stage: build
       displayName: Build

--- a/libcxxabi/src/cxa_personality.cpp
+++ b/libcxxabi/src/cxa_personality.cpp
@@ -1123,14 +1123,11 @@ __gxx_personality_seh0(PEXCEPTION_RECORD ms_exc, void *this_frame,
 static _Unwind_Reason_Code continue_unwind(_Unwind_Exception* unwind_exception,
                                            _Unwind_Context* context)
 {
-  switch (__gnu_unwind_frame(unwind_exception, context)) {
-  case _URC_OK:
-    return _URC_CONTINUE_UNWIND;
-  case _URC_END_OF_STACK:
-    return _URC_END_OF_STACK;
-  default:
-    return _URC_FAILURE;
-  }
+  // dotnet: __gnu_unwind_frame is not available in the azurelinux cross-compilation sysroot.
+  // The LLVM tools built for ARM32 do not rely on C++ exception propagation.
+  (void)unwind_exception;
+  (void)context;
+  __builtin_trap();
 }
 
 // ARM register names

--- a/llvm.proj
+++ b/llvm.proj
@@ -101,6 +101,7 @@
     <_LLVMBuildArgs Include='-DLLVM_EXTERNALIZE_DEBUGINFO_INSTALL=ON' />
     <_LLVMBuildArgs Include='-DCOMPILER_RT_USE_LLVM_UNWINDER=OFF' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_ENABLE_PDB=ON' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_PARALLEL_LINK_JOBS=2' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLEGAL_COPYRIGHT="\xa9 Microsoft Corporation. All rights reserved."' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dbg' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'OSX'" Include='-DLLVM_EXTERNALIZE_DEBUGINFO_EXTENSION=dwarf -DLLVM_EXTERNALIZE_DEBUGINFO_FLATTEN=ON' />

--- a/llvm.proj
+++ b/llvm.proj
@@ -176,7 +176,7 @@
       <_LibCxxBuildArgs Include='-DCMAKE_POSITION_INDEPENDENT_CODE=ON' />
       <_LibCxxBuildArgs Include="-DCMAKE_CXX_COMPILER_TARGET=$(ClangTarget)" />
       <_LibCxxBuildArgs Include="-DLLVM_DEFAULT_TARGET_TRIPLE=$(ClangTarget)" />
-      <_LibCxxBuildArgs Include="-DLIBCXXABI_USE_LLVM_UNWINDER=ON" />
+      <_LibCxxBuildArgs Include="-DLIBCXXABI_USE_LLVM_UNWINDER=OFF" />
       <_LibCxxBuildArgs Include="-DLIBCXX_INCLUDE_TESTS=OFF" />
       <_LibCxxBuildArgs Include="-DLIBCXXABI_INCLUDE_TESTS=OFF" />
       <_LibCxxBuildArgs Condition="$(ClangTarget.ToLowerInvariant().Contains('musl'))" Include="-DLIBCXX_HAS_MUSL_LIBC=ON" />

--- a/llvm.proj
+++ b/llvm.proj
@@ -27,7 +27,7 @@
     </_SetupEnvironment>
     <_CMakeConfigureCommand>$(_SetupEnvironment) cmake $(_LLVMSourceDir) -G "$(CMakeGenerator)" @(_LLVMBuildArgs->'%(Identity)',' ')</_CMakeConfigureCommand>
     <_LibCxxConfigureCommand>$(_SetupEnvironment) cmake $(_LibCxxSourceDir) -G "$(CMakeGenerator)" @(_LibCxxBuildArgs->'%(Identity)',' ')</_LibCxxConfigureCommand>
-    <_BuildSubset Condition="'$(BuildLLVMTableGenOnly)' == 'true'">llvm-tblgen clang-tblgen llvm-config clang-tidy-confusable-chars-gen clang-pseudo-gen</_BuildSubset>
+    <_BuildSubset Condition="'$(BuildLLVMTableGenOnly)' == 'true'">llvm-tblgen clang-tblgen llvm-config clang-tidy-confusable-chars-gen</_BuildSubset>
     <_BuildSubset Condition="'$(BuildJitToolsOnly)' == 'true'">llvm-mca llvm-dwarfdump FileCheck</_BuildSubset>
     <_BuildCommand Condition="'$(CMakeGenerator)' == 'Unix Makefiles'">$(_SetupEnvironment) make $(_BuildSubset) -j$([System.Environment]::ProcessorCount)</_BuildCommand>
     <_BuildCommand Condition="'$(CMakeGenerator)' == 'Ninja'">$(_SetupEnvironment) ninja $(_BuildSubset)</_BuildCommand>
@@ -123,9 +123,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildOS)' != 'Windows_NT'">
-    <_LLVMBuildArgs Include="-DCMAKE_C_COMPILER=clang-20" />
-    <_LLVMBuildArgs Include="-DCMAKE_CXX_COMPILER=clang++-20" />
-    <_LLVMBuildArgs Include="-DCMAKE_ASM_COMPILER=clang-20" />
+    <_LLVMBuildArgs Include="-DCMAKE_C_COMPILER=clang" />
+    <_LLVMBuildArgs Include="-DCMAKE_CXX_COMPILER=clang++" />
+    <_LLVMBuildArgs Include="-DCMAKE_ASM_COMPILER=clang" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildOS)' == 'Linux'">
@@ -162,9 +162,9 @@
   <Target Name="_LibCxxBootstrap" Condition="'$(BuildOS)' == 'Linux'" BeforeTargets="_LLVMBuild">
     <ItemGroup>
       <_LibCxxBuildArgs Include='-DLLVM_ENABLE_RUNTIMES="libcxx%3Blibcxxabi%3Blibunwind"' />
-      <_LibCxxBuildArgs Include="-DCMAKE_C_COMPILER=clang-20" />
-      <_LibCxxBuildArgs Include="-DCMAKE_CXX_COMPILER=clang++-20" />
-      <_LibCxxBuildArgs Include="-DCMAKE_ASM_COMPILER=clang-20" />
+      <_LibCxxBuildArgs Include="-DCMAKE_C_COMPILER=clang" />
+      <_LibCxxBuildArgs Include="-DCMAKE_CXX_COMPILER=clang++" />
+      <_LibCxxBuildArgs Include="-DCMAKE_ASM_COMPILER=clang" />
       <_LibCxxBuildArgs Include='-DCMAKE_C_FLAGS="-D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CMakeExtraCFlags) -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CFlags)"' />
       <_LibCxxBuildArgs Include='-DCMAKE_CXX_FLAGS="-D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CMakeExtraCFlags) -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CFlags)"' />
       <_LibCxxBuildArgs Include='-DCMAKE_ASM_FLAGS="-D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CMakeExtraCFlags) -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS $(_CFlags)"' />

--- a/llvm.proj
+++ b/llvm.proj
@@ -110,6 +110,7 @@
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_NATIVE_TOOL_DIR=$(NativeTablegenDir)' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' != 'Windows_NT'" Include='-DLLVM_ENABLE_ZLIB=FORCE_ON' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' != 'Windows_NT' and '$(LibsRoot)' != ''" Include='-DZLIB_ROOT=$(LibsRoot)' />
+    <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Linux' and '$(ROOTFS_DIR)' != ''" Include='-DZLIB_INCLUDE_DIR=$(ROOTFS_DIR)/usr/include' />
     <_LLVMBuildArgs Condition="'$(BuildOS)' == 'Windows_NT'" Include='-DLLVM_ENABLE_ZLIB=OFF' />
     <_LLVMBuildArgs Include='-DLLVM_ENABLE_PROJECTS="lld%3Bclang%3Bclang-tools-extra"' />
     <_LLVMBuildArgs Include='-DLLVM_BUILD_TOOLS:BOOL=ON' />
@@ -175,7 +176,7 @@
       <_LibCxxBuildArgs Include='-DCMAKE_POSITION_INDEPENDENT_CODE=ON' />
       <_LibCxxBuildArgs Include="-DCMAKE_CXX_COMPILER_TARGET=$(ClangTarget)" />
       <_LibCxxBuildArgs Include="-DLLVM_DEFAULT_TARGET_TRIPLE=$(ClangTarget)" />
-      <_LibCxxBuildArgs Include="-DLIBCXXABI_USE_LLVM_UNWINDER=OFF" />
+      <_LibCxxBuildArgs Include="-DLIBCXXABI_USE_LLVM_UNWINDER=ON" />
       <_LibCxxBuildArgs Include="-DLIBCXX_INCLUDE_TESTS=OFF" />
       <_LibCxxBuildArgs Include="-DLIBCXXABI_INCLUDE_TESTS=OFF" />
       <_LibCxxBuildArgs Condition="$(ClangTarget.ToLowerInvariant().Contains('musl'))" Include="-DLIBCXX_HAS_MUSL_LIBC=ON" />

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -2591,9 +2591,17 @@ function(llvm_externalize_debuginfo name)
     set(output_name "$<TARGET_FILE_NAME:${name}>.${file_ext}")
 
     if(LLVM_EXTERNALIZE_DEBUGINFO_OUTPUT_DIR)
-      set(output_path "-o=${LLVM_EXTERNALIZE_DEBUGINFO_OUTPUT_DIR}/${output_name}")
+      set(output_path "${LLVM_EXTERNALIZE_DEBUGINFO_OUTPUT_DIR}/${output_name}")
     else()
-      set(output_path "-o=${output_name}")
+      set(output_path "${output_name}")
+    endif()
+
+    set(output_flag "-o=${output_path}")
+
+    if(LLVM_EXTERNALIZE_DEBUGINFO_FLATTEN)
+      set(flatten_flag "--flat")
+    else()
+      set(flatten_flag "")
     endif()
 
     if(CMAKE_CXX_FLAGS MATCHES "-flto"
@@ -2606,13 +2614,9 @@ function(llvm_externalize_debuginfo name)
     if(NOT CMAKE_DSYMUTIL)
       set(CMAKE_DSYMUTIL xcrun dsymutil)
     endif()
-    if(LLVM_EXTERNALIZE_DEBUGINFO_FLATTEN)
-      set(flatten_flag "--flat")
-    else()
-      set(flatten_flag "")
-    endif()
     add_custom_command(TARGET ${name} POST_BUILD
-      COMMAND ${CMAKE_DSYMUTIL} ${flatten_flag} ${output_path} $<TARGET_FILE:${name}>
+      WORKING_DIRECTORY ${LLVM_RUNTIME_OUTPUT_INTDIR}
+      COMMAND ${CMAKE_DSYMUTIL} ${flatten_flag} ${output_flag} $<TARGET_FILE:${name}>
       ${strip_command}
       )
     if(LLVM_EXTERNALIZE_DEBUGINFO_INSTALL AND ARG_DEBUGINFO_INSTALL)

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -2606,8 +2606,13 @@ function(llvm_externalize_debuginfo name)
     if(NOT CMAKE_DSYMUTIL)
       set(CMAKE_DSYMUTIL xcrun dsymutil)
     endif()
+    if(LLVM_EXTERNALIZE_DEBUGINFO_FLATTEN)
+      set(flatten_flag "--flat")
+    else()
+      set(flatten_flag "")
+    endif()
     add_custom_command(TARGET ${name} POST_BUILD
-      COMMAND ${CMAKE_DSYMUTIL} ${output_path} $<TARGET_FILE:${name}>
+      COMMAND ${CMAKE_DSYMUTIL} ${flatten_flag} ${output_path} $<TARGET_FILE:${name}>
       ${strip_command}
       )
     if(LLVM_EXTERNALIZE_DEBUGINFO_INSTALL AND ARG_DEBUGINFO_INSTALL)


### PR DESCRIPTION
# [wasm] Bump LLVM to 23 with Mono patches

https://github.com/dotnet/llvm-project/tree/dotnet/main-23.x
https://github.com/dotnet/llvm-project/commits/dotnet/main-23.x/

## Summary

Bump LLVM from 19.x to 23.x for .NET 11 Mono AOT, including all required Mono-specific patches ported from `dotnet/main-19.x`.

Based on upstream `llvm/llvm-project` at [`bbeae6932d65`](https://github.com/llvm/llvm-project/commit/bbeae6932d653b8a71a3a985af0ccf97e13e2e08).

## Changes

### Infrastructure
- Strip tests, fuzzers, docs, examples, benchmarks, unused subprojects for scan-area reduction
- Add dotnet Arcade scaffolding (from `dotnet/main-19.x` [`db9a80a3e25e`](https://github.com/dotnet/llvm-project/commit/db9a80a3e25e))
- Bump `MONO_API_VERSION` to 2300
- Use `clang`/`clang++` (no version suffix) for build, disable libcxx tests
- Remove `clang-pseudo-gen` from `BuildLLVMTableGenOnly` targets (removed in LLVM 23)
- Upgrade CI container images from `cbl-mariner-2.0-cross-*` to `azurelinux-3.0-net11.0-cross-*`
- Add `ZLIB_INCLUDE_DIR` for crossrootfs builds (azurelinux image layout)
- Restore `LLVM_EXTERNALIZE_DEBUGINFO_FLATTEN` support (`--flat` dsymutil flag, removed upstream in LLVM 23)
- Stub `__gnu_unwind_frame` in libcxxabi for ARM32 (not declared in azurelinux crossrootfs headers; LLVM tools don't use C++ exception propagation)

### Mono calling convention & EH tables (ported from dotnet/main-19.x)
- Reserve calling-convention slot 22 for Mono (`CallingConv::Mono = 22`)
- Add Mono calling convention implementation for AArch64, ARM, X86
- Add `MonoException` EH table emitter
- Add mono-specific FaultMaps and WinException handling
- Add `monocc` keyword to IR parser/writer

### Mono-specific codegen fixes (ported from dotnet/main-19.x)
- Disable function specialization (breaks Mono AOT EH frame code range)
- Add mono calling convention to `AArch64RegisterInfo::isArgumentRegister`
- Avoid crashing in `ImplicitNullChecks` on alias detection failure
- Turn off MSVC optimizations in `StreamChecker.cpp` on MSVC < 1941

### LLVM 23 API compatibility fixes
- Add `MachineFunction::MonoThisSlot` field (API changed from 19.x)
- Replace removed `addDebugHandler()` with `Handlers.push_back()`
- Replace removed `MMI->hasDebugInfo()` with `Asm->hasDebugInfo()`
- Add `Type *OrigTy` parameter to AArch64 Mono CC declarations (new in 23)
- Fix `Subtarget->isAAPCS_ABI()` → `getTM().isAAPCS_ABI()` (moved in 23)

## Cherry-picked from `dotnet/llvm-project` `dotnet/main-19.x`

| Original SHA | Description |
|---|---|
| [`151e0291b2b7`](https://github.com/dotnet/llvm-project/commit/151e0291b2b7) | Add support for emitting mono specific EH tables (#430) |
| [`781355b29c36`](https://github.com/dotnet/llvm-project/commit/781355b29c36) | Fix build |
| [`8bc171058077`](https://github.com/dotnet/llvm-project/commit/8bc171058077) | Turn off MSVC optimizations in StreamChecker.cpp on MSVC < 1941 (#586) |
| [`0a0f2df0eb68`](https://github.com/dotnet/llvm-project/commit/0a0f2df0eb68) | [mono] Add mono calling convention to AArch64RegisterInfo::isArgumentRegister (#579) |
| [`e1d0e64410a8`](https://github.com/dotnet/llvm-project/commit/e1d0e64410a8) | Disable function specialization (#599) |
| [`24cb568d905e`](https://github.com/dotnet/llvm-project/commit/24cb568d905e) | Fix build |
| [`845a24eafccf`](https://github.com/dotnet/llvm-project/commit/845a24eafccf) | Add TODO comment to MonoException |
| [`e619541ecf42`](https://github.com/dotnet/llvm-project/commit/e619541ecf42) | Fix MonoException |
| [`743e2d8715e2`](https://github.com/dotnet/llvm-project/commit/743e2d8715e2) | Fix MonoExceptionDebugHandler |
| [`39455743c6e2`](https://github.com/dotnet/llvm-project/commit/39455743c6e2) | Avoid crashing in case of alias detection failure (#607) |

## Not ported (already in LLVM 23 upstream)

| Original SHA | Description |
|---|---|
| [`6fb3dcbf3ffc`](https://github.com/dotnet/llvm-project/commit/6fb3dcbf3ffc) | [lld][WebAssembly] Ignore local symbols when parsing lazy object files |

## Build verification

Locally verified: `clang`, `llc`, and `lld` all build and link successfully with targets X86, AArch64, ARM, WebAssembly. The `--enable-mono-eh-frame` flag is registered and functional in `llc`.

## Related

- PR: https://github.com/dotnet/llvm-project/pull/746
- Tracking issue: https://github.com/dotnet/runtime/issues/113786
- Emsdk bump PR: https://github.com/dotnet/emsdk/pull/1712
