### PR TITLE
[Core.cpp] Restore implicit truncation in LLVMConstInt

### DIFF
--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -1567,7 +1567,13 @@ unsigned LLVMGetDebugLocColumn(LLVMValueRef Val) {
 
 LLVMValueRef LLVMConstInt(LLVMTypeRef IntTy, unsigned long long N,
                           LLVMBool SignExtend) {
-  return wrap(ConstantInt::get(unwrap<IntegerType>(IntTy), N, SignExtend != 0));
+  // The LLVM-C API has historically truncated N implicitly to IntTy's width.
+  // Pass ImplicitTrunc=true to preserve that contract; otherwise out-of-range
+  // values (e.g. -1 sign-extended to 0xFFFFFFFFFFFFFFFF being passed for an
+  // i32) trigger an assertion in debug builds and produce a ConstantInt with
+  // unused bits left set in release builds, breaking subsequent folding.
+  return wrap(ConstantInt::get(unwrap<IntegerType>(IntTy), N, SignExtend != 0,
+                               /*ImplicitTrunc=*/true));
 }
 
 LLVMValueRef LLVMConstIntOfArbitraryPrecision(LLVMTypeRef IntTy,


### PR DESCRIPTION
Upstream LLVM PR https://github.com/llvm/llvm-project/pull/171456 (commit 47fc1dd90ed4) flipped the default of ConstantInt::get's ImplicitTrunc parameter from true to false. Since LLVMConstInt does not explicitly pass ImplicitTrunc, it inherits the new default. This is a behavior change at the stable LLVM-C API boundary: callers passing 'unsigned long long N' values that don't fit the target integer type's width (e.g. -1 sign-extended to 0xFFFFFFFFFFFFFFFF being passed for an i32) now trigger an APInt assertion failure in debug builds, and in release builds produce a ConstantInt whose internal APInt has its unused bits left set, breaking subsequent constant folding.

LLVMConstInt has always documented N as implicitly truncated/extended to the target width. Restore that contract by explicitly passing ImplicitTrunc=true. Note that LLVM 22.x took an equivalent approach by reverting PR https://github.com/llvm/llvm-project/pull/171456 from its release branch.