### PR TITLE
Preserve NaN when narrowing to `half` in InstCombine

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -2205,6 +2205,53 @@ Instruction *InstCombinerImpl::visitFPTrunc(FPTruncInst &FPT) {
   if (Instruction *I = commonCastTransforms(FPT))
     return I;
 
+  // Some targets/toolchains can mishandle NaN payloads when narrowing to half
+  // and produce infinities for NaN inputs. Preserve NaN behavior by guarding
+  // half truncation with an explicit isnan select.
+  if (FPT.getType()->getScalarType()->isHalfTy() && !FPT.hasNoNaNs()) {
+    auto IsProtectedHalfTrunc = [&]() {
+      if (!FPT.hasOneUse())
+        return false;
+
+      auto *Sel = dyn_cast<SelectInst>(*FPT.user_begin());
+      if (!Sel)
+        return false;
+
+      CmpPredicate Pred;
+      Value *CmpL, *CmpR;
+      // InstCombine canonicalizes 'fcmp uno %src, %src' to
+      // 'fcmp uno %src, 0.0', so accept either form for the isnan check.
+      if (!match(Sel->getCondition(),
+                 m_FCmp(Pred, m_Value(CmpL), m_Value(CmpR))) ||
+          Pred != CmpInst::FCMP_UNO || CmpL != FPT.getOperand(0) ||
+          (CmpR != FPT.getOperand(0) && !match(CmpR, m_AnyZeroFP())))
+        return false;
+
+      // Use m_NaN so vector splats of NaN are also recognized.
+      auto IsNaNConst = [](Value *V) { return match(V, m_NaN()); };
+
+      return (Sel->getTrueValue() == &FPT && IsNaNConst(Sel->getFalseValue())) ||
+             (Sel->getFalseValue() == &FPT && IsNaNConst(Sel->getTrueValue()));
+    };
+
+    if (!IsProtectedHalfTrunc()) {
+      Value *Src = FPT.getOperand(0);
+      Value *IsNaN = Builder.CreateFCmpUNO(Src, Src, "isnan");
+
+      Type *DstTy = FPT.getType();
+      Type *EltTy = DstTy->getScalarType();
+      Constant *QNaNScalar = ConstantFP::getQNaN(EltTy);
+      Constant *QNaN = isa<VectorType>(DstTy)
+                           ? ConstantVector::getSplat(
+                                 cast<VectorType>(DstTy)->getElementCount(),
+                                 QNaNScalar)
+                           : QNaNScalar;
+
+      Value *Trunc = Builder.CreateFPTruncFMF(Src, DstTy, &FPT);
+      return SelectInst::Create(IsNaN, QNaN, Trunc);
+    }
+  }
+
   // If we have fptrunc(OpI (fpextend x), (fpextend y)), we would like to
   // simplify this expression to avoid one or more of the trunc/extend
   // operations if we can do so without changing the numerical results.


### PR DESCRIPTION
## Summary

Some targets/toolchains mishandle NaN payloads when narrowing a floating-point
value to `half` (fp16) and can produce an **infinity** for a NaN input. This
change teaches `InstCombinerImpl::visitFPTrunc` to preserve NaN semantics by
guarding `fptrunc … to half` with an explicit `isnan` check, so a NaN input is
always lowered to a (quiet) NaN result rather than risking an infinity.

## Motivation

A `fptrunc` of a NaN must yield a NaN. On the affected lowering paths this
invariant was broken, turning NaN inputs into infinities and producing wrong
numerical results in Mono workloads. Materializing the NaN guard at the IR
level makes the result correct regardless of how the backend lowers the
narrowing.

## Change

File: `llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp`

When the destination scalar type is `half` and the `fptrunc` is **not** marked
`nnan`, the truncation is rewritten as:

```llvm
%isnan = fcmp uno <T> %src, %src
%trunc = fptrunc <T> %src to <half...>     ; original FMF preserved
%res   = select <i1...> %isnan, <half...> qnan, <half...> %trunc
```

i.e. `select(isnan(src), qnan, fptrunc(src))`.

Behavior details:

- Applies to both scalar `half` and vectors of `half`; the quiet-NaN constant is
  splatted for vector destinations.
- Skips truncations that already carry the `nnan` fast-math flag (NaN can't
  occur, so no guard is needed).
- Fast-math flags from the original `fptrunc` are propagated to the inner
  truncation.
- Replaces the NaN payload/sign with a canonical quiet NaN (`getQNaN`). NaN-ness
  is preserved; the exact payload is not (which is the intent, since the
  affected lowering mishandled payloads).

### Idempotency / termination

`visitFPTrunc` revisits the inner `fptrunc` it creates, so the transform must
recognize its own output and not re-fire. An `IsProtectedHalfTrunc` helper
detects the already-guarded pattern and bails out. Two subtleties are handled so
InstCombine reliably reaches a fixed point:

- **Compare canonicalization.** InstCombine canonicalizes `fcmp uno %src, %src`
  to `fcmp uno %src, 0.0` (see `InstCombineCompares.cpp`). The guard therefore
  accepts either the `%src, %src` form or a zero right-hand side
  (`m_AnyZeroFP()`).
- **Vector NaN constants.** The guarding NaN arm of the `select` is a
  `ConstantFP` for scalars but a splat (`ConstantVector`) for vectors. The check
  uses `m_NaN()`, which matches both scalar and splat NaN constants.

Without these, the protection check would fail to recognize the freshly emitted
guard and InstCombine would not converge (repeated re-expansion / infinite-loop
detection).
