### PR TITLE
Add JavaScript to the CodeQL language matrix

### DIFF
--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -15,7 +15,7 @@ variables:
   - name: Codeql.Enabled
     value: True
   - name: Codeql.Language
-    value: cpp,python
+    value: cpp,javascript,python
   - name: Codeql.Cadence
     value: 0
   - name: Codeql.TSAEnabled


### PR DESCRIPTION
## Description

Extend `Codeql.Language` from `cpp,python` to `cpp,javascript,python`, so that the JavaScript sources in this repository are analysed alongside the existing C++ and Python coverage.

This pipeline is the only place CodeQL runs for this repository, because the main build sets `Codeql.Enabled` to false to avoid timeouts on Windows. The existing seven day cadence is unchanged.

The change affects only the internal pipeline. Public pull request validation does not run CodeQL, so the checks here confirm that the build is unaffected rather than that the analysis succeeds. Verification of the JavaScript database requires the next internal run after merge.
