### PR TITLE
Remove DotNet-VSTS-Bot variable group from dotnet/main-19.x

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -18,7 +18,6 @@ variables:
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     - group: Publish-Build-Assets
-    - group: DotNet-VSTS-Bot
     - group: DotNet-HelixApi-Access
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)


### PR DESCRIPTION
Removes the `DotNet-VSTS-Bot` (VG10) import from `eng/common-variables.yml` on `dotnet/main-19.x`. Current expanded YAML resolves this group even though the expired PAT is not used at runtime.

Tracking: https://dnceng.visualstudio.com/internal/_workitems/edit/11016