### PR TITLE
Remove DotNet-VSTS-Bot from release/8.0 SDL job

### DIFF
--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -36,7 +36,6 @@ jobs:
   displayName: Run SDL tool
   condition: and(succeededOrFailed(), eq( ${{ parameters.enable }}, 'true'))
   variables:
-    - group: DotNet-VSTS-Bot
     - name: AzDOProjectName
       value: ${{ parameters.AzDOProjectName }}
     - name: AzDOPipelineId


### PR DESCRIPTION
Removes the `DotNet-VSTS-Bot` (VG10) import from the conditional SDL job in `eng/common/templates/job/execute-sdl.yml` on `dotnet/release/8.0`. The group is excluded from current expanded plans, but retaining the source reference could reactivate it under different template parameters.

Tracking: https://dnceng.visualstudio.com/internal/_workitems/edit/11016