### PR TITLE
Report GitHub identity for LLVM CodeQL uploads

### DIFF
--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -22,6 +22,14 @@ variables:
     value: True
   - name: Codeql.BuildIdentifier
     value: $(System.JobDisplayName)
+  # Attribute mirrored source to GitHub without changing the build checkout.
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Repository.Name'], 'dotnet-llvm-project')) }}:
+    - name: Codeql.ADO.Build.Repository.Provider
+      value: GitHub
+    - name: Codeql.ADO.Build.Repository.Uri
+      value: https://github.com/dotnet/llvm-project
+    - name: Codeql.ADO.Build.SourceBranchName
+      value: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 
 stages:
 - stage: Build

--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -22,7 +22,6 @@ variables:
     value: True
   - name: Codeql.BuildIdentifier
     value: $(System.JobDisplayName)
-  # Attribute mirrored source to GitHub without changing the build checkout.
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Repository.Name'], 'dotnet-llvm-project')) }}:
     - name: Codeql.ADO.Build.Repository.Provider
       value: GitHub


### PR DESCRIPTION
## Description

Report CodeQL uploads under the GitHub repository instead of the internal ADO mirror.
